### PR TITLE
fix: solve multiple rerun problem

### DIFF
--- a/osa_tool/github_agent/github_agent.py
+++ b/osa_tool/github_agent/github_agent.py
@@ -190,14 +190,7 @@ class GithubAgent:
             logger.info("Push completed.")
             return True
         except GitCommandError as e:
-            logger.error(
-                f"""Push failed: Branch '{branch}' already exists in the fork.
-             To resolve this, please either:
-                1. Choose a different branch name that doesn't exist in the fork 
-                   by modifying the `branch_name` parameter.
-                2. Delete the existing branch from forked repository.
-                3. Delete the fork entirely.""")
-            return False
+            raise
 
     def create_pull_request(self, title: str = None, body: str = None) -> None:
         """Creates a pull request from the forked repository to the original repository.

--- a/osa_tool/github_agent/github_agent.py
+++ b/osa_tool/github_agent/github_agent.py
@@ -296,7 +296,7 @@ class GithubAgent:
             self.repo.git.checkout("-f", report_branch)
             with open(report_filepath, "wb") as f:
                 f.write(preserved_content)
-            logger.info(f"Sucessfuly moved PDF report to {report_branch} branch.")
+            logger.info(f"Successfully moved PDF report to {report_branch} branch.")
 
         try:
             self.commit_and_push_changes(

--- a/osa_tool/github_agent/github_agent.py
+++ b/osa_tool/github_agent/github_agent.py
@@ -257,7 +257,7 @@ class GithubAgent:
             with open(report_filepath, "rb") as f:
                 preserved_content = f.read()
             self.repo.git.checkout("-f", report_branch)
-            with open(report_branch, "wb") as f:
+            with open(report_filepath, "wb") as f:
                 f.write(preserved_content)
             logger.info(f"Sucessfuly moved PDF report to {report_branch} branch.")
 

--- a/osa_tool/github_agent/github_agent.py
+++ b/osa_tool/github_agent/github_agent.py
@@ -190,6 +190,7 @@ class GithubAgent:
         Args:
             branch: The name of the branch to push changes to. Defaults to `branch_name`.
             commit_message: The commit message. Defaults to "osa_tool recommendations".
+            force: Option to force push the commit. Defaults to `False`
         """
         if not self.fork_url:
             raise ValueError("Fork URL is not set. Please create a fork first.")
@@ -280,7 +281,8 @@ class GithubAgent:
         """Uploads the generated PDF report to a separate branch.
 
         Args:
-            report_filename: The name of the report file.
+            report_filename: Name of the report file.
+            report_filepath: Path to the repoft file.
             report_branch: Name of the branch for storing reports. Defaults to "osa_tool_attachments".
             commit_message: Commit message for the report upload. Defaults to "upload pdf report".
         """

--- a/osa_tool/github_agent/github_agent.py
+++ b/osa_tool/github_agent/github_agent.py
@@ -249,6 +249,12 @@ class GithubAgent:
             report_branch: Name of the branch for storing reports. Defaults to "osa_tool_attachments".
             commit_message: Commit message for the report upload. Defaults to "upload pdf report".
         """
+        if not self.fork_url:
+            logger.error(
+                "Fork URL is not set. Please create a fork first. Skipping uploading PDF report."
+            )
+            return
+
         self.create_and_checkout_branch(report_branch)
         self.commit_and_push_changes(report_branch, commit_message)
         self.create_and_checkout_branch()  # Return to original branch

--- a/osa_tool/github_agent/github_agent.py
+++ b/osa_tool/github_agent/github_agent.py
@@ -241,7 +241,13 @@ class GithubAgent:
             if not "pull request already exists" in response.text:
                 raise ValueError("Failed to create pull request.")
 
-    def upload_report(self, report_filename: str, report_branch: str = "osa_tool_attachments", commit_message: str = "upload pdf report") -> None:
+    def upload_report(
+        self,
+        report_filename: str,
+        report_filepath: str,
+        report_branch: str = "osa_tool_attachments",
+        commit_message: str = "upload pdf report",
+    ) -> None:
         """Uploads the generated PDF report to a separate branch.
 
         Args:

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -99,7 +99,7 @@ def main():
         analytics = ReportGenerator(config, sourcerank, github_agent.clone_dir)
         analytics.build_pdf()
         if publish_results:
-            github_agent.upload_report(analytics.filename)
+            github_agent.upload_report(analytics.filename, analytics.output_path)
 
         # Auto translating names of directories
         if args.translate_dirs:

--- a/tests/unit/github_agent/test_commit_push.py
+++ b/tests/unit/github_agent/test_commit_push.py
@@ -1,5 +1,6 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 
 
 def test_commit_and_push_changes_success(github_agent):
@@ -20,7 +21,7 @@ def test_commit_and_push_changes_success(github_agent):
     github_agent.repo.git.add.assert_called_once_with(".")
     github_agent.repo.git.commit.assert_called_once_with("-m", "Test commit")
     github_agent.repo.git.push.assert_called_once_with(
-        "--set-upstream", "origin", "feature-branch", force_with_lease=True
+        "--set-upstream", "origin", "feature-branch", force_with_lease=True, force=False
     )
     mock_logger.info.assert_any_call("Committing changes...")
     mock_logger.info.assert_any_call("Commit completed.")

--- a/tests/unit/github_agent/test_upload_report.py
+++ b/tests/unit/github_agent/test_upload_report.py
@@ -6,11 +6,12 @@ import pytest
 def test_upload_report_success(github_agent):
     # Arrange
     report_filename = "test_report.pdf"
+    report_filepath = "test/filepath"
     default_report_branch = "osa_tool_attachments"
     default_message = "upload pdf report"
 
     # Act
-    github_agent.upload_report(report_filename)
+    github_agent.upload_report(report_filename, report_filepath)
 
     # Assert
     github_agent.repo.git.checkout.assert_has_calls(
@@ -19,7 +20,11 @@ def test_upload_report_success(github_agent):
     github_agent.repo.git.add.assert_called_once_with(".")
     github_agent.repo.git.commit.assert_called_once_with("-m", default_message)
     github_agent.repo.git.push.assert_called_once_with(
-        "--set-upstream", "origin", default_report_branch, force_with_lease=True
+        "--set-upstream",
+        "origin",
+        default_report_branch,
+        force_with_lease=False,
+        force=True,
     )
 
     expected_report_url = (
@@ -34,12 +39,16 @@ def test_upload_report_success(github_agent):
 def test_upload_report_custom_branch_and_message(github_agent):
     # Arrange
     report_filename = "custom_report.pdf"
+    report_filepath = "test/filepath"
     custom_branch = "custom_branch"
     custom_message = "custom message"
 
     # Act
     github_agent.upload_report(
-        report_filename, report_branch=custom_branch, commit_message=custom_message
+        report_filename,
+        report_filepath,
+        report_branch=custom_branch,
+        commit_message=custom_message,
     )
 
     # Assert
@@ -49,7 +58,7 @@ def test_upload_report_custom_branch_and_message(github_agent):
     github_agent.repo.git.add.assert_called_once_with(".")
     github_agent.repo.git.commit.assert_called_once_with("-m", custom_message)
     github_agent.repo.git.push.assert_called_once_with(
-        "--set-upstream", "origin", custom_branch, force_with_lease=True
+        "--set-upstream", "origin", custom_branch, force_with_lease=False, force=True
     )
 
     expected_report_url = (
@@ -64,12 +73,13 @@ def test_upload_report_custom_branch_and_message(github_agent):
 def test_upload_report_existing_branch(github_agent):
     # Arrange
     report_filename = "test_report.pdf"
+    report_filepath = "test/filepath"
     default_report_branch = "osa_tool_attachments"
     github_agent.repo.heads = {default_report_branch: None}
     default_message = "upload pdf report"
 
     # Act
-    github_agent.upload_report(report_filename)
+    github_agent.upload_report(report_filename, report_filepath)
 
     # Assert
     github_agent.repo.git.checkout.assert_has_calls(
@@ -78,5 +88,9 @@ def test_upload_report_existing_branch(github_agent):
     github_agent.repo.git.add.assert_called_once_with(".")
     github_agent.repo.git.commit.assert_called_once_with("-m", default_message)
     github_agent.repo.git.push.assert_called_once_with(
-        "--set-upstream", "origin", default_report_branch, force_with_lease=True
+        "--set-upstream",
+        "origin",
+        default_report_branch,
+        force_with_lease=False,
+        force=True,
     )


### PR DESCRIPTION
- [x] Fix report uploading:
  - [x] Repo just downloaded, but fork exists
  - [x] Checkout to report branch when re-run multiple times
  - [x] Refactor if needed
- [x] Update tests

Closes #149 
Closes #165 

This pull request introduces enhancements to the `osa_tool` codebase, focusing on improving the functionality and robustness of the `upload_report` and `commit_and_push_changes` methods. Additionally, it updates unit tests to ensure coverage for the new features and edge cases. 

### Feature Enhancements:

* [`osa_tool/github_agent/github_agent.py`](diffhunk://#diff-7eb2846b6fd626256df7a6b3145bc1c5d3f68ecb1e69b9bc6fb234dff4338105L183-R186): Added a `force` parameter to the `commit_and_push_changes` method, allowing forced pushes when necessary. Updated the `upload_report` method to handle cases where the report branch already exists and to move the report file safely between branches. [[1]](diffhunk://#diff-7eb2846b6fd626256df7a6b3145bc1c5d3f68ecb1e69b9bc6fb234dff4338105L183-R186) [[2]](diffhunk://#diff-7eb2846b6fd626256df7a6b3145bc1c5d3f68ecb1e69b9bc6fb234dff4338105L205-R216) [[3]](diffhunk://#diff-7eb2846b6fd626256df7a6b3145bc1c5d3f68ecb1e69b9bc6fb234dff4338105R287-R310)

* [`osa_tool/run.py`](diffhunk://#diff-bfb7a699dcee695a9c934b483c7070fe067ac5dd62cdb725bb055386592dc0d0L99-R99): Modified the `upload_report` method call to include the report's file path, ensuring proper handling of the report file during uploads.

### Unit Test Updates:

* [`tests/unit/github_agent/test_commit_push.py`](diffhunk://#diff-b0492e73b65425d4726192833634b655d1fbcba1fefc7def2904a11327b786ceR1-L2): Updated the `test_commit_and_push_changes_success` test to validate the behavior of the new `force` parameter in the `commit_and_push_changes` method. [[1]](diffhunk://#diff-b0492e73b65425d4726192833634b655d1fbcba1fefc7def2904a11327b786ceR1-L2) [[2]](diffhunk://#diff-b0492e73b65425d4726192833634b655d1fbcba1fefc7def2904a11327b786ceL23-R24)

* [`tests/unit/github_agent/test_upload_report.py`](diffhunk://#diff-854d7258355a338e4ff318db8c7f411ed04227933ac8b5f6f561cc84f6467f0dR4-R15): Added new tests to cover scenarios such as commit failures due to `.gitignore` restrictions and handling existing branches during report uploads. Updated existing tests to accommodate the `report_filepath` parameter and the `force` option in pushes. [[1]](diffhunk://#diff-854d7258355a338e4ff318db8c7f411ed04227933ac8b5f6f561cc84f6467f0dR4-R15) [[2]](diffhunk://#diff-854d7258355a338e4ff318db8c7f411ed04227933ac8b5f6f561cc84f6467f0dR40-R68) [[3]](diffhunk://#diff-854d7258355a338e4ff318db8c7f411ed04227933ac8b5f6f561cc84f6467f0dL52-R78) [[4]](diffhunk://#diff-854d7258355a338e4ff318db8c7f411ed04227933ac8b5f6f561cc84f6467f0dL81-R112)