### PR TITLE
fix: improve error messages for streamlit web app

### DIFF
--- a/osa_tool/git_agent/git_agent.py
+++ b/osa_tool/git_agent/git_agent.py
@@ -361,7 +361,7 @@ class GitAgent:
                     )
                 else:
                     logger.error("An unexpected Git error occurred while cloning the repository.")
-                raise
+                raise Exception(f"Cannot clone the repository: {self.repo_url}") from e
 
     def create_and_checkout_branch(self, branch: str = None) -> None:
         """Creates and checks out a new branch.

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -1,10 +1,12 @@
-import os
 import asyncio
 import multiprocessing
+import os
 import subprocess
 import sys
 from pathlib import Path
 from typing import Optional
+
+from pydantic import ValidationError
 
 from osa_tool.aboutgen.about_generator import AboutGenerator
 from osa_tool.analytics.report_maker import ReportGenerator
@@ -316,7 +318,11 @@ def load_configuration(
     """
     config_loader = ConfigLoader()
 
-    config_loader.config.git = GitSettings(repository=repo_url)
+    try:
+        config_loader.config.git = GitSettings(repository=repo_url)
+    except ValidationError as es:
+        first_error = es.errors()[0]
+        raise ValueError(f"{first_error["msg"]}{first_error["input"]}")
     config_loader.config.llm = config_loader.config.llm.model_copy(
         update={
             "api": api,

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -175,7 +175,7 @@ def main():
         sys.exit(0)
 
     except Exception as e:
-        logger.error("Error: %s", e, exc_info=True)
+        logger.error("Error: %s", e, exc_info=False if args.web_mode else True)
         sys.exit(1)
 
     finally:

--- a/osa_tool/utils.py
+++ b/osa_tool/utils.py
@@ -134,7 +134,7 @@ def parse_git_url(repo_url: str) -> tuple[str, str, str, str]:
     parsed_url = urlparse(repo_url)
 
     if parsed_url.scheme not in ["http", "https"]:
-        raise ValueError(f"Unknown scheme provided: {parsed_url.scheme}")
+        raise ValueError(f"Provided URL is not correct: {parsed_url.scheme}")
 
     if not parsed_url.netloc:
         raise ValueError(f"Invalid Git repository URL: {parsed_url}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "osa_tool"
-version = "0.2.1.1"
+version = "0.2.2"
 description = "Tool that just makes your open source project better!"
 requires-python = ">=3.10,<4.0"
 authors = [


### PR DESCRIPTION
# Description:

This PR implements the following updates:

- Reduces general error messages to a single line in web mode.
- Implements specific handling for Pydantic validation errors with input validation.
- Handles failed repository clone.

Closes https://github.com/aimclub/OSA/issues/276 #279

---

# Examples:

## General purpose error

### Without --web-mode
<img width="1534" height="242" alt="image" src="https://github.com/user-attachments/assets/9f6e5520-c2e6-4b5b-ba6d-73ed6c8c0c73" />


### With --web-mode
<img width="1540" height="108" alt="image" src="https://github.com/user-attachments/assets/9f563a9f-eabf-4fc4-833d-bd7a81297c63" />

## Pydantic validation error

### Before

#### Without --web-mode
<img width="1536" height="312" alt="image" src="https://github.com/user-attachments/assets/1bfb15b5-1b55-46de-a16c-f28897f88813" />

#### With --web-mode
<img width="1535" height="94" alt="image" src="https://github.com/user-attachments/assets/c6de2909-9bad-45de-a1fd-f72f688e4ea5" />


### After

#### Without --web-mode
<img width="1520" height="399" alt="image" src="https://github.com/user-attachments/assets/760d0fcd-bf32-4072-8300-0b17526199bd" />

#### With --web-mode
<img width="1520" height="61" alt="image" src="https://github.com/user-attachments/assets/4b1d85ce-0344-4bc5-9499-57b66ebec320" />

