### PR TITLE
feature: add allowed providers for external API

### DIFF
--- a/osa_tool/config/settings.py
+++ b/osa_tool/config/settings.py
@@ -55,6 +55,7 @@ class ModelSettings(BaseModel):
     max_tokens: PositiveInt
     context_window: PositiveInt
     top_p: NonNegativeFloat
+    allowed_providers: list[str]
 
 
 class WorkflowSettings(BaseModel):

--- a/osa_tool/config/settings/config.toml
+++ b/osa_tool/config/settings/config.toml
@@ -18,6 +18,8 @@ temperature = 0.05
 max_tokens = 4096 
 context_window = 16385 
 top_p = 0.95
+allowed_providers = ["google-vertex", "azure"]
+
 
 # General CLI-related defaults
 [general]

--- a/osa_tool/models/models.py
+++ b/osa_tool/models/models.py
@@ -230,7 +230,11 @@ class ProtollmHandler(ModelHandler):
         """
         dotenv.load_dotenv()
 
-        self.client = create_llm_connector(model_url=self._build_model_url(), **self._get_llm_params())
+        self.client = create_llm_connector(
+            model_url=self._build_model_url(),
+            extra_body={"providers": {"only": self.config.llm.allowed_providers}},
+            **self._get_llm_params(),
+        )
 
     def _limit_tokens(self, text: str, safety_buffer: int = 100, mode: str = "middle-out") -> str:
         """

--- a/tests/data_factory.py
+++ b/tests/data_factory.py
@@ -52,6 +52,7 @@ class DataFactory:
             "max_tokens": random.randint(512, 4096),
             "context_window": random.randint(8192, 16385),
             "top_p": round(random.uniform(0.1, 1.0), 1),
+            "allowed_providers": random.sample(["google-vertex", "azure"], k=1),
         }
 
     @staticmethod


### PR DESCRIPTION
## Description

This PR fixes the stochastic provider selection issue when using an external LLM API by adding an `allowed_providers` field to the configuration file.