### PR TITLE
feature: OSA CI/CD mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - name: Install dependencies
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,7 @@ runs:
           -r "https://github.com/${{ github.repository }}" \
           -b "${{ github.head_ref }}" \
           --mode ${{ inputs.mode }} \
+          --web-mode \
           --no-fork \
           --no-pull-request \
           --docstring \

--- a/action.yml
+++ b/action.yml
@@ -84,13 +84,6 @@ runs:
           CHANGED_FILES="${{ steps.changed-files.outputs.all_changed_files }}"
           for file in $CHANGED_FILES; do
             if [ -f "./$REPO_NAME/$file" ]; then
-        
-              # --- ОТЛАДКА: СМОТРИМ ЧТО НАПИСАЛА ОСА ---
-              echo ">>> CONTENT OF $file AFTER OSA: <<<"
-              cat "./$REPO_NAME/$file"
-              echo ">>> END OF CONTENT <<<"
-              # ----------------------------------------
-        
               mkdir -p $(dirname "./$file")
               cp -a "./$REPO_NAME/$file" "./$file"
               echo "Synced: $file"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,58 @@
+name: 'Open Source Advisor Action'
+description: 'Automatically generates missing docstrings and audits your repository'
+author: 'aimclub'
+
+inputs:
+  openai_api_key:
+    description: 'Your OpenAI or OpenRouter API Key'
+    required: true
+  github_token:
+    description: 'GitHub Token for repository access'
+    required: true
+    default: ${{ github.token }}
+  mode:
+    description: 'OSA processing mode'
+    required: false
+    default: 'advanced'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r ${{ github.action_path }}/requirements.txt
+        pip install ${{ github.action_path }}
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v44
+      with:
+        files: '**.py'
+
+    - name: Run OSA
+      shell: bash
+      env:
+        OPENAI_API_KEY: ${{ inputs.openai_api_key }}
+        GIT_TOKEN: ${{ inputs.github_token }}
+      run: |
+        python -m osa_tool.run \
+          -r "https://github.com/${{ github.repository }}" \
+          -b "${{ github.head_ref }}" \
+          --mode ${{ inputs.mode }} \
+          --no-fork \
+          --no-pull-request \
+          --docstring \
+          --incremental \
+          --target-files ${{ steps.changed-files.outputs.all_changed_files }}
+
+    - name: Sync and Commit
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "docs(osa): auto-generate missing docstrings"

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,32 @@ runs:
           --incremental \
           --target-files ${{ steps.changed-files.outputs.all_changed_files }}
 
-    - name: Sync and Commit
+    - name: Sync modified files back to workspace
+      shell: bash
+      if: steps.changed-files.outputs.any_changed == 'true'
+      run: |
+        REPO_NAME=$(basename ${{ github.repository }})
+        
+        if [ -d "$REPO_NAME" ]; then
+          echo "Syncing modified files from $REPO_NAME back to workspace root..."
+        
+          rm -rf "./$REPO_NAME/.git"
+        
+          # Флаг -a сохраняет права доступа, -T копирует содержимое
+          cp -aT "./$REPO_NAME/" "./"
+        
+          rm -rf "./$REPO_NAME"
+        
+          echo "Sync complete."
+        else
+          echo "Directory $REPO_NAME not found. Skipping sync."
+        fi
+
+    - name: Commit and Push changes
+      if: steps.changed-files.outputs.any_changed == 'true'
       uses: stefanzweifel/git-auto-commit-action@v5
       with:
         commit_message: "docs(osa): auto-generate missing docstrings"
+        file_pattern: "*.py"
+        commit_user_name: "osa-bot"
+        commit_user_email: "osa-bot@users.noreply.github.com"

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ runs:
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}
         GIT_TOKEN: ${{ inputs.github_token }}
       run: |
+        REPO_NAME=$(basename ${{ github.repository }})
+        
+        rm -rf "$REPO_NAME"
+        
         python -m osa_tool.run \
           -r "https://github.com/${{ github.repository }}" \
           -b "${{ github.head_ref }}" \

--- a/action.yml
+++ b/action.yml
@@ -84,9 +84,16 @@ runs:
           CHANGED_FILES="${{ steps.changed-files.outputs.all_changed_files }}"
           for file in $CHANGED_FILES; do
             if [ -f "./$REPO_NAME/$file" ]; then
+        
+              # --- ОТЛАДКА: СМОТРИМ ЧТО НАПИСАЛА ОСА ---
+              echo ">>> CONTENT OF $file AFTER OSA: <<<"
+              cat "./$REPO_NAME/$file"
+              echo ">>> END OF CONTENT <<<"
+              # ----------------------------------------
+        
               mkdir -p $(dirname "./$file")
               cp -a "./$REPO_NAME/$file" "./$file"
-              echo "✅ Synced: $file"
+              echo "Synced: $file"
             fi
           done
           rm -rf "./$REPO_NAME"

--- a/action.yml
+++ b/action.yml
@@ -1,17 +1,32 @@
 name: 'Open Source Advisor Action'
-description: 'Automatically generates missing docstrings and audits your repository'
+description: 'Automatically generates missing docstrings and audits your repository using various LLM providers'
 author: 'aimclub'
 
 inputs:
+  # Tokens (Secrets)
   openai_api_key:
-    description: 'Your OpenAI or OpenRouter API Key'
-    required: true
+    description: 'API key for OpenAI, VseGPT or OpenRouter'
+    required: false
+  authorization_key:
+    description: 'API key for GigaChat provider'
+    required: false
   github_token:
     description: 'GitHub Token for repository access'
     required: true
     default: ${{ github.token }}
+
+  # LLM Settings
+  api:
+    description: 'LLM Provider (openai, itmo, ollama, gigachat)'
+    required: false
+  base_url:
+    description: 'API Base URL'
+    required: false
+  model:
+    description: 'LLM Model name'
+    required: false
   mode:
-    description: 'OSA processing mode'
+    description: 'OSA processing mode (basic, auto, advanced)'
     required: false
     default: 'advanced'
 
@@ -39,50 +54,45 @@ runs:
     - name: Run OSA
       shell: bash
       env:
+        # Try and get all possible tokens that we have
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}
+        AUTHORIZATION_KEY: ${{ inputs.authorization_key }}
         GIT_TOKEN: ${{ inputs.github_token }}
       run: |
         REPO_NAME=$(basename ${{ github.repository }})
-        
         rm -rf "$REPO_NAME"
-        
-        python -m osa_tool.run \
-          -r "https://github.com/${{ github.repository }}" \
-          -b "${{ github.head_ref }}" \
-          --mode ${{ inputs.mode }} \
-          --web-mode \
-          --no-fork \
-          --no-pull-request \
-          --docstring \
-          --incremental \
-          --target-files ${{ steps.changed-files.outputs.all_changed_files }}
 
-    - name: Sync modified files back to workspace
+        # Base command
+        CMD="python -m osa_tool.run -r https://github.com/${{ github.repository }} -b ${{ github.head_ref }} --web-mode --no-fork --no-pull-request --docstring --incremental --target-files ${{ steps.changed-files.outputs.all_changed_files }}"
+        
+        # Dynamic argument adding (if they are added by user)
+        if [ -n "${{ inputs.mode }}" ]; then CMD="$CMD --mode ${{ inputs.mode }}"; fi
+        if [ -n "${{ inputs.api }}" ]; then CMD="$CMD --api ${{ inputs.api }}"; fi
+        if [ -n "${{ inputs.base_url }}" ]; then CMD="$CMD --base-url ${{ inputs.base_url }}"; fi
+        if [ -n "${{ inputs.model }}" ]; then CMD="$CMD --model ${{ inputs.model }}"; fi
+        
+        echo "Executing: $CMD"
+        $CMD
+
+    - name: Sync modified files
       shell: bash
       if: steps.changed-files.outputs.any_changed == 'true'
       run: |
         REPO_NAME=$(basename ${{ github.repository }})
-        
         if [ -d "$REPO_NAME" ]; then
           echo "Syncing ONLY target files from cloned directory..."
-        
           CHANGED_FILES="${{ steps.changed-files.outputs.all_changed_files }}"
-        
           for file in $CHANGED_FILES; do
             if [ -f "./$REPO_NAME/$file" ]; then
               mkdir -p $(dirname "./$file")
               cp -a "./$REPO_NAME/$file" "./$file"
-              echo "Synced: $file"
+              echo "✅ Synced: $file"
             fi
           done
-        
           rm -rf "./$REPO_NAME"
-          echo "Sync complete."
-        else
-          echo "Directory $REPO_NAME not found. Skipping sync."
         fi
 
-    - name: Commit and Push changes
+    - name: Commit and Push
       if: steps.changed-files.outputs.any_changed == 'true'
       uses: stefanzweifel/git-auto-commit-action@v5
       with:

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
@@ -47,7 +47,7 @@ runs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v44
+      uses: tj-actions/changed-files@v47
       with:
         files: '**.py'
 
@@ -63,7 +63,7 @@ runs:
         rm -rf "$REPO_NAME"
 
         # Base command
-        CMD="python -m osa_tool.run -r https://github.com/${{ github.repository }} -b ${{ github.head_ref }} --web-mode --no-fork --no-pull-request --docstring --incremental --target-files ${{ steps.changed-files.outputs.all_changed_files }}"
+        CMD="python -m osa_tool.run -r https://github.com/${{ github.repository }} -b ${{ github.head_ref || github.ref_name }} --web-mode --no-fork --no-pull-request --docstring --incremental --target-files ${{ steps.changed-files.outputs.all_changed_files }}"
         
         # Dynamic argument adding (if they are added by user)
         if [ -n "${{ inputs.mode }}" ]; then CMD="$CMD --mode ${{ inputs.mode }}"; fi
@@ -94,7 +94,7 @@ runs:
 
     - name: Commit and Push
       if: steps.changed-files.outputs.any_changed == 'true'
-      uses: stefanzweifel/git-auto-commit-action@v5
+      uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: "docs(osa): auto-generate missing docstrings"
         file_pattern: "*.py"

--- a/action.yml
+++ b/action.yml
@@ -64,7 +64,6 @@ runs:
         
           rm -rf "./$REPO_NAME/.git"
         
-          # Флаг -a сохраняет права доступа, -T копирует содержимое
           cp -aT "./$REPO_NAME/" "./"
         
           rm -rf "./$REPO_NAME"

--- a/action.yml
+++ b/action.yml
@@ -64,14 +64,19 @@ runs:
         REPO_NAME=$(basename ${{ github.repository }})
         
         if [ -d "$REPO_NAME" ]; then
-          echo "Syncing modified files from $REPO_NAME back to workspace root..."
+          echo "Syncing ONLY target files from cloned directory..."
         
-          rm -rf "./$REPO_NAME/.git"
+          CHANGED_FILES="${{ steps.changed-files.outputs.all_changed_files }}"
         
-          cp -aT "./$REPO_NAME/" "./"
+          for file in $CHANGED_FILES; do
+            if [ -f "./$REPO_NAME/$file" ]; then
+              mkdir -p $(dirname "./$file")
+              cp -a "./$REPO_NAME/$file" "./$file"
+              echo "Synced: $file"
+            fi
+          done
         
           rm -rf "./$REPO_NAME"
-        
           echo "Sync complete."
         else
           echo "Directory $REPO_NAME not found. Skipping sync."

--- a/osa_tool/config/settings.py
+++ b/osa_tool/config/settings.py
@@ -36,6 +36,7 @@ class GitSettings(BaseModel):
     host_domain: str | None = None
     host: str | None = None
     name: str = ""
+    osa_branch_name: str = "osa_tool"
 
     @model_validator(mode="after")
     def set_git_attributes(self):

--- a/osa_tool/config/settings/arguments.yaml
+++ b/osa_tool/config/settings/arguments.yaml
@@ -57,6 +57,17 @@ arguments:
       If flag omitted only __init__.py will be ignored.
     example: "tests moduleA/featureB __init__.py"
 
+  incremental:
+    aliases: [ "--incremental" ]
+    type: flag
+    description: "Enable incremental mode for tasks (e.g., generate docstrings only for missing ones and skip main idea update)."
+
+  target_files:
+    aliases: [ "--target-files" ]
+    type: list
+    description: "Space-separated list of specific files to analyze. If set, OSA will focus only on these files."
+    example: "path/to/file1.py path/to/file2.py"
+
   report:
     aliases: [ "--report" ]
     type: flag

--- a/osa_tool/config/settings/config.toml
+++ b/osa_tool/config/settings/config.toml
@@ -50,6 +50,8 @@ organize = false
 about = false
 validate_paper = false
 validate_doc = false
+incremental = false
+target_files = []
 
 #Workflow Settings
 [workflows]

--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -346,8 +346,8 @@ class GitAgent(abc.ABC):
                 logger.error(f"Directory {self.clone_dir} exists but is not a valid Git repository")
                 raise
 
-        elif self._check_branch_existence():
-            self._clone_chosen_branch()
+        elif self._check_branch_existence(None):
+            self._clone_chosen_branch(None)
         else:
             self._clone_default_branch()
 

--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -38,7 +38,15 @@ class GitAgent(abc.ABC):
         pr_report_body: A formatted message for a pull request.
     """
 
-    def __init__(self, repo_url: str, repo_branch_name: str = None, branch_name: str = "osa_tool", author: str = None):
+    DEFAULT_BRANCH_NAME = "osa_tool"
+
+    def __init__(
+            self,
+            repo_url: str,
+            repo_branch_name: str = None,
+            branch_name: str = DEFAULT_BRANCH_NAME,
+            author: str = None
+    ):
         """Initializes the agent with repository info.
 
         Args:

--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -41,11 +41,7 @@ class GitAgent(abc.ABC):
     DEFAULT_BRANCH_NAME = "osa_tool"
 
     def __init__(
-            self,
-            repo_url: str,
-            repo_branch_name: str = None,
-            branch_name: str = DEFAULT_BRANCH_NAME,
-            author: str = None
+        self, repo_url: str, repo_branch_name: str = None, branch_name: str = DEFAULT_BRANCH_NAME, author: str = None
     ):
         """Initializes the agent with repository info.
 

--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -38,11 +38,7 @@ class GitAgent(abc.ABC):
         pr_report_body: A formatted message for a pull request.
     """
 
-    DEFAULT_BRANCH_NAME = "osa_tool"
-
-    def __init__(
-        self, repo_url: str, repo_branch_name: str = None, branch_name: str = DEFAULT_BRANCH_NAME, author: str = None
-    ):
+    def __init__(self, repo_url: str, repo_branch_name: str = None, branch_name: str = "osa_tool", author: str = None):
         """Initializes the agent with repository info.
 
         Args:

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -435,15 +435,12 @@ class DocGen(object):
         method_source = method_details["source_code"].replace("\r\n", "\n")
 
         # method_body = DocGen.strip_docstring_from_body(method_source.strip())
-        docstring_clean = DocGen.extract_pure_docstring(generated_docstring.replace("\r\n", "\n"))
+        docstring_clean = DocGen.extract_pure_docstring(generated_docstring.replace("\r\n", F"\n"))
 
         # Find method within a source code
-        match = re.search(re.escape(method_source), source_code) # TODO: поменять на обычный find
-        if not match:
-            return source_code
-        body_start = match.start()
+        body_start = source_code.find(method_source)
 
-        if not body_start:
+        if body_start == -1:
             return source_code
 
         start = body_start
@@ -470,7 +467,7 @@ class DocGen(object):
         # Check for existing docstring right after signature
         signature_end_index = None
         for i, line in enumerate(method_lines):
-            if line.strip().endswith(":"):
+            if line.split('#')[0].strip().endswith(":"):
                 signature_end_index = i
                 break
 

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -435,7 +435,7 @@ class DocGen(object):
         method_source = method_details["source_code"].replace("\r\n", "\n")
 
         # method_body = DocGen.strip_docstring_from_body(method_source.strip())
-        docstring_clean = DocGen.extract_pure_docstring(generated_docstring.replace("\r\n", F"\n"))
+        docstring_clean = DocGen.extract_pure_docstring(generated_docstring.replace("\r\n", f"\n"))
 
         # Find method within a source code
         body_start = source_code.find(method_source)
@@ -467,7 +467,7 @@ class DocGen(object):
         # Check for existing docstring right after signature
         signature_end_index = None
         for i, line in enumerate(method_lines):
-            if line.split('#')[0].strip().endswith(":"):
+            if line.split("#")[0].strip().endswith(":"):
                 signature_end_index = i
                 break
 

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -434,11 +434,11 @@ class DocGen(object):
         source_code = source_code.replace("\r\n", "\n")
         method_source = method_details["source_code"].replace("\r\n", "\n")
 
-        method_body = DocGen.strip_docstring_from_body(method_source.strip())
+        # method_body = DocGen.strip_docstring_from_body(method_source.strip())
         docstring_clean = DocGen.extract_pure_docstring(generated_docstring.replace("\r\n", "\n"))
 
         # Find method within a source code
-        match = re.search(re.escape(method_source), source_code)
+        match = re.search(re.escape(method_source), source_code) # TODO: поменять на обычный find
         if not match:
             return source_code
         body_start = match.start()

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -424,45 +424,37 @@ class DocGen(object):
 
     @staticmethod
     def insert_docstring_in_code(
-            source_code: str, method_details: dict, generated_docstring: str, class_method: bool = False
+        source_code: str, method_details: dict, generated_docstring: str, class_method: bool = False
     ) -> str:
-        method_name = method_details.get('method_name', 'UNKNOWN')
-        logger.warning(f"==================================================")
-        logger.warning(f"🛠️ DEBUG START for: {method_name}")
-
-        if not generated_docstring or not generated_docstring.strip():
-            logger.error(f"❌ DEBUG: Empty generated docstring!")
-            return source_code
-
-        # 1. Нормализация
+        """
+        Inserts or replaces a method-level docstring in the provided source code,
+        using the method's body from method_details['source_code'] to locate the method.
+        Handles multi-line signatures, decorators, async definitions, and existing docstrings.
+        """
         source_code = source_code.replace("\r\n", "\n")
         method_source = method_details["source_code"].replace("\r\n", "\n")
 
+        method_body = DocGen.strip_docstring_from_body(method_source.strip())
         docstring_clean = DocGen.extract_pure_docstring(generated_docstring.replace("\r\n", "\n"))
-        logger.warning(f"✅ DEBUG: Cleaned docstring: {repr(docstring_clean[:50])}...")
 
-        # 2. Поиск
+        # Find method within a source code
         match = re.search(re.escape(method_source), source_code)
         if not match:
-            logger.error(f"❌ DEBUG: Regex match failed!")
-            logger.error(f"   Source code length: {len(source_code)}")
-            logger.error(f"   Method source snippet: {repr(method_source[:50])}...")
+            return source_code
+        body_start = match.start()
+
+        if not body_start:
             return source_code
 
-        body_start = match.start()
-        logger.warning(f"✅ DEBUG: Regex matched at index {body_start}")
-
         start = body_start
+
         while start > 0 and source_code[start - 1] in " \t\n":
             start -= 1
 
         end = body_start + len(method_source)
-        logger.warning(f"✅ DEBUG: Slice indices: start={start}, body_start={body_start}, end={end}")
 
         method_block = source_code[start:end]
         method_lines = method_block.splitlines(keepends=True)
-
-        logger.warning(f"✅ DEBUG: Extracted {len(method_lines)} lines for method_block.")
 
         indent = "        " if class_method else "    "
 
@@ -475,59 +467,47 @@ class DocGen(object):
                 indented.append(f"{indent}{line}")
             return "\n".join(indented) + "\n"
 
-        # 3. Ищем сигнатуру
+        # Check for existing docstring right after signature
         signature_end_index = None
         for i, line in enumerate(method_lines):
             if line.strip().endswith(":"):
                 signature_end_index = i
                 break
 
-        if signature_end_index is None:
-            logger.error(f"❌ DEBUG: Failed to find ':' in method_lines! Here is the block:\n{repr(method_block)}")
-            return source_code
-
-        logger.warning(f"✅ DEBUG: Found ':' at line index {signature_end_index}")
-
         docstring_inserted = indent_docstring(docstring_clean)
 
-        next_line_index = signature_end_index + 1
-        while next_line_index < len(method_lines) and method_lines[next_line_index].strip() == "":
-            next_line_index += 1
+        if signature_end_index is not None:
+            next_line_index = signature_end_index + 1
+            while next_line_index < len(method_lines) and method_lines[next_line_index].strip() == "":
+                next_line_index += 1
 
-        is_replacement = False
-        if next_line_index < len(method_lines) and method_lines[next_line_index].strip().startswith(('"""', "'''")):
-            is_replacement = True
-            logger.warning(f"✅ DEBUG: Existing docstring found, replacing...")
-            # Замена существующего (оставил твою логику)
-            closing = method_lines[next_line_index].strip()[:3]
-            end_doc_idx = next_line_index
+            if next_line_index < len(method_lines) and method_lines[next_line_index].strip().startswith(('"""', "'''")):
+                # Replace old docstring
+                closing = method_lines[next_line_index].strip()[:3]
+                end_doc_idx = next_line_index
 
-            if len(method_lines[next_line_index].strip()) > 3 and method_lines[next_line_index].strip().endswith(
-                    closing):
-                method_lines = method_lines[:next_line_index] + [docstring_inserted] + method_lines[end_doc_idx + 1:]
-                updated_block = "".join(method_lines)
-                logger.warning(f"✅ DEBUG: Replaced 1-liner. Returning.")
-                return source_code[:start] + updated_block + source_code[end:]
+                if len(method_lines[next_line_index].strip()) > 3 and method_lines[next_line_index].strip().endswith(
+                    closing
+                ):
+                    method_lines = (
+                        method_lines[:next_line_index] + [docstring_inserted] + method_lines[end_doc_idx + 1 :]
+                    )
+                    updated_block = "".join(method_lines)
+                    result = source_code[:start] + updated_block + source_code[end:]
+                    return result
 
-            for j in range(next_line_index + 1, len(method_lines)):
-                if closing in method_lines[j]:
-                    end_doc_idx = j
-                    break
-            method_lines = method_lines[:next_line_index] + [docstring_inserted] + method_lines[end_doc_idx + 1:]
-        else:
-            logger.warning(f"✅ DEBUG: No existing docstring. Inserting new one at index {signature_end_index + 1}...")
-            # Вставка
-            method_lines.insert(signature_end_index + 1, docstring_inserted)
+                for j in range(next_line_index + 1, len(method_lines)):
+                    if closing in method_lines[j]:
+                        end_doc_idx = j
+                        break
+                method_lines = method_lines[:next_line_index] + [docstring_inserted] + method_lines[end_doc_idx + 1 :]
+            else:
+                # Insert new docstring
+                method_lines.insert(signature_end_index + 1, docstring_inserted)
 
         updated_block = "".join(method_lines)
-
-        # --- ФИНАЛЬНАЯ ПРОВЕРКА ЧТО МЫ ОТДАЕМ ---
-        logger.warning(f"✅ DEBUG: Old block length: {len(method_block)}. New block length: {len(updated_block)}")
-        if method_block == updated_block:
-            logger.error("❌ DEBUG: updated_block IS IDENTICAL to method_block! Insertion failed logically.")
-
         result = source_code[:start] + updated_block + source_code[end:]
-        logger.warning(f"==================================================")
+
         return result
 
     @staticmethod

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -431,6 +431,13 @@ class DocGen(object):
         using the method's body from method_details['source_code'] to locate the method.
         Handles multi-line signatures, decorators, async definitions, and existing docstrings.
         """
+        method_name = method_details.get('method_name', 'UNKNOWN')
+        logger.warning(f"Attempting to insert docstring for '{method_name}'")
+
+        if not generated_docstring or not generated_docstring.strip():
+            logger.error(f"Generated docstring is empty/None for {method_name}")
+            return source_code
+
         method_body = DocGen.strip_docstring_from_body(method_details["source_code"].strip())
         docstring_clean = DocGen.extract_pure_docstring(generated_docstring)
 

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -431,15 +431,11 @@ class DocGen(object):
         using the method's body from method_details['source_code'] to locate the method.
         Handles multi-line signatures, decorators, async definitions, and existing docstrings.
         """
-        method_name = method_details.get('method_name', 'UNKNOWN')
-        logger.warning(f"Attempting to insert docstring for '{method_name}'")
+        source_code = source_code.replace("\r\n", "\n")
+        method_source = method_details["source_code"].replace("\r\n", "\n")
 
-        if not generated_docstring or not generated_docstring.strip():
-            logger.error(f"Generated docstring is empty/None for {method_name}")
-            return source_code
-
-        method_body = DocGen.strip_docstring_from_body(method_details["source_code"].strip())
-        docstring_clean = DocGen.extract_pure_docstring(generated_docstring)
+        method_body = DocGen.strip_docstring_from_body(method_source.strip())
+        docstring_clean = DocGen.extract_pure_docstring(generated_docstring.replace("\r\n", "\n"))
 
         # Find method within a source code
         match = re.search(re.escape(method_details["source_code"]), source_code)
@@ -455,7 +451,7 @@ class DocGen(object):
         while start > 0 and source_code[start - 1] in " \t\n":
             start -= 1
 
-        end = body_start + len(method_body)
+        end = body_start + len(method_source)
 
         method_block = source_code[start:end]
         method_lines = method_block.splitlines(keepends=True)
@@ -465,7 +461,7 @@ class DocGen(object):
         def indent_docstring(docstring: str) -> str:
             lines = docstring.strip().splitlines()
             if len(lines) == 1:
-                return f'{indent}"""{lines[0]}"""'
+                return f'{indent}"""{lines[0]}"""\n'
             indented = [f"{indent}" + lines[0]]
             for line in lines[1:]:
                 indented.append(f"{indent}{line}")

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -434,7 +434,6 @@ class DocGen(object):
         source_code = source_code.replace("\r\n", "\n")
         method_source = method_details["source_code"].replace("\r\n", "\n")
 
-        # method_body = DocGen.strip_docstring_from_body(method_source.strip())
         docstring_clean = DocGen.extract_pure_docstring(generated_docstring.replace("\r\n", f"\n"))
 
         # Find method within a source code

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -424,37 +424,45 @@ class DocGen(object):
 
     @staticmethod
     def insert_docstring_in_code(
-        source_code: str, method_details: dict, generated_docstring: str, class_method: bool = False
+            source_code: str, method_details: dict, generated_docstring: str, class_method: bool = False
     ) -> str:
-        """
-        Inserts or replaces a method-level docstring in the provided source code,
-        using the method's body from method_details['source_code'] to locate the method.
-        Handles multi-line signatures, decorators, async definitions, and existing docstrings.
-        """
+        method_name = method_details.get('method_name', 'UNKNOWN')
+        logger.warning(f"==================================================")
+        logger.warning(f"🛠️ DEBUG START for: {method_name}")
+
+        if not generated_docstring or not generated_docstring.strip():
+            logger.error(f"❌ DEBUG: Empty generated docstring!")
+            return source_code
+
+        # 1. Нормализация
         source_code = source_code.replace("\r\n", "\n")
         method_source = method_details["source_code"].replace("\r\n", "\n")
 
-        method_body = DocGen.strip_docstring_from_body(method_source.strip())
         docstring_clean = DocGen.extract_pure_docstring(generated_docstring.replace("\r\n", "\n"))
+        logger.warning(f"✅ DEBUG: Cleaned docstring: {repr(docstring_clean[:50])}...")
 
-        # Find method within a source code
-        match = re.search(re.escape(method_details["source_code"]), source_code)
+        # 2. Поиск
+        match = re.search(re.escape(method_source), source_code)
         if not match:
+            logger.error(f"❌ DEBUG: Regex match failed!")
+            logger.error(f"   Source code length: {len(source_code)}")
+            logger.error(f"   Method source snippet: {repr(method_source[:50])}...")
             return source_code
-        body_start = match.start()
 
-        if not body_start:
-            return source_code
+        body_start = match.start()
+        logger.warning(f"✅ DEBUG: Regex matched at index {body_start}")
 
         start = body_start
-
         while start > 0 and source_code[start - 1] in " \t\n":
             start -= 1
 
         end = body_start + len(method_source)
+        logger.warning(f"✅ DEBUG: Slice indices: start={start}, body_start={body_start}, end={end}")
 
         method_block = source_code[start:end]
         method_lines = method_block.splitlines(keepends=True)
+
+        logger.warning(f"✅ DEBUG: Extracted {len(method_lines)} lines for method_block.")
 
         indent = "        " if class_method else "    "
 
@@ -467,47 +475,59 @@ class DocGen(object):
                 indented.append(f"{indent}{line}")
             return "\n".join(indented) + "\n"
 
-        # Check for existing docstring right after signature
+        # 3. Ищем сигнатуру
         signature_end_index = None
         for i, line in enumerate(method_lines):
             if line.strip().endswith(":"):
                 signature_end_index = i
                 break
 
+        if signature_end_index is None:
+            logger.error(f"❌ DEBUG: Failed to find ':' in method_lines! Here is the block:\n{repr(method_block)}")
+            return source_code
+
+        logger.warning(f"✅ DEBUG: Found ':' at line index {signature_end_index}")
+
         docstring_inserted = indent_docstring(docstring_clean)
 
-        if signature_end_index is not None:
-            next_line_index = signature_end_index + 1
-            while next_line_index < len(method_lines) and method_lines[next_line_index].strip() == "":
-                next_line_index += 1
+        next_line_index = signature_end_index + 1
+        while next_line_index < len(method_lines) and method_lines[next_line_index].strip() == "":
+            next_line_index += 1
 
-            if next_line_index < len(method_lines) and method_lines[next_line_index].strip().startswith(('"""', "'''")):
-                # Replace old docstring
-                closing = method_lines[next_line_index].strip()[:3]
-                end_doc_idx = next_line_index
+        is_replacement = False
+        if next_line_index < len(method_lines) and method_lines[next_line_index].strip().startswith(('"""', "'''")):
+            is_replacement = True
+            logger.warning(f"✅ DEBUG: Existing docstring found, replacing...")
+            # Замена существующего (оставил твою логику)
+            closing = method_lines[next_line_index].strip()[:3]
+            end_doc_idx = next_line_index
 
-                if len(method_lines[next_line_index].strip()) > 3 and method_lines[next_line_index].strip().endswith(
-                    closing
-                ):
-                    method_lines = (
-                        method_lines[:next_line_index] + [docstring_inserted] + method_lines[end_doc_idx + 1 :]
-                    )
-                    updated_block = "".join(method_lines)
-                    result = source_code[:start] + updated_block + source_code[end:]
-                    return result
+            if len(method_lines[next_line_index].strip()) > 3 and method_lines[next_line_index].strip().endswith(
+                    closing):
+                method_lines = method_lines[:next_line_index] + [docstring_inserted] + method_lines[end_doc_idx + 1:]
+                updated_block = "".join(method_lines)
+                logger.warning(f"✅ DEBUG: Replaced 1-liner. Returning.")
+                return source_code[:start] + updated_block + source_code[end:]
 
-                for j in range(next_line_index + 1, len(method_lines)):
-                    if closing in method_lines[j]:
-                        end_doc_idx = j
-                        break
-                method_lines = method_lines[:next_line_index] + [docstring_inserted] + method_lines[end_doc_idx + 1 :]
-            else:
-                # Insert new docstring
-                method_lines.insert(signature_end_index + 1, docstring_inserted)
+            for j in range(next_line_index + 1, len(method_lines)):
+                if closing in method_lines[j]:
+                    end_doc_idx = j
+                    break
+            method_lines = method_lines[:next_line_index] + [docstring_inserted] + method_lines[end_doc_idx + 1:]
+        else:
+            logger.warning(f"✅ DEBUG: No existing docstring. Inserting new one at index {signature_end_index + 1}...")
+            # Вставка
+            method_lines.insert(signature_end_index + 1, docstring_inserted)
 
         updated_block = "".join(method_lines)
-        result = source_code[:start] + updated_block + source_code[end:]
 
+        # --- ФИНАЛЬНАЯ ПРОВЕРКА ЧТО МЫ ОТДАЕМ ---
+        logger.warning(f"✅ DEBUG: Old block length: {len(method_block)}. New block length: {len(updated_block)}")
+        if method_block == updated_block:
+            logger.error("❌ DEBUG: updated_block IS IDENTICAL to method_block! Insertion failed logically.")
+
+        result = source_code[:start] + updated_block + source_code[end:]
+        logger.warning(f"==================================================")
         return result
 
     @staticmethod

--- a/osa_tool/operations/codebase/docstring_generation/docstring_generation.py
+++ b/osa_tool/operations/codebase/docstring_generation/docstring_generation.py
@@ -31,7 +31,6 @@ class DocstringsGenerator:
         self.dg = DocGen(self.config_manager)
         self.ts = OSA_TreeSitter(self.repo_path, self.ignore_list, target_files=self.target_files, )
         self.events: list[OperationEvent] = []
-
     def run(self) -> dict:
         """
         Sync entrypoint without explicit loop.

--- a/osa_tool/operations/codebase/docstring_generation/docstring_generation.py
+++ b/osa_tool/operations/codebase/docstring_generation/docstring_generation.py
@@ -29,7 +29,7 @@ class DocstringsGenerator:
         self.repo_path = parse_folder_name(self.repo_url)
 
         self.dg = DocGen(self.config_manager)
-        self.ts = OSA_TreeSitter(self.repo_path, self.ignore_list, target_files=self.target_files)
+        self.ts = OSA_TreeSitter(self.repo_path, self.ignore_list, target_files=self.target_files, )
         self.events: list[OperationEvent] = []
 
     def run(self) -> dict:

--- a/osa_tool/operations/codebase/docstring_generation/docstring_generation.py
+++ b/osa_tool/operations/codebase/docstring_generation/docstring_generation.py
@@ -14,9 +14,13 @@ class DocstringsGenerator:
         self,
         config_manager: ConfigManager,
         ignore_list: list[str],
+        incremental: bool = False,
+        target_files: list[str] = None,
     ) -> None:
         self.config_manager = config_manager
         self.ignore_list = ignore_list
+        self.incremental = incremental
+        self.target_files = target_files
 
         self.sem = asyncio.Semaphore(100)
         self.workers = multiprocessing.cpu_count()
@@ -25,8 +29,7 @@ class DocstringsGenerator:
         self.repo_path = parse_folder_name(self.repo_url)
 
         self.dg = DocGen(self.config_manager)
-        self.ts = OSA_TreeSitter(self.repo_path, self.ignore_list)
-
+        self.ts = OSA_TreeSitter(self.repo_path, self.ignore_list, target_files=self.target_files)
         self.events: list[OperationEvent] = []
 
     def run(self) -> dict:
@@ -96,6 +99,13 @@ class DocstringsGenerator:
 
             await self.dg._write_augmented_code(res, cl_augmented, self.sem)
             self._emit(EventKind.WRITTEN, target="classes_docstrings")
+
+            if self.incremental:
+                logger.info("Incremental mode active. Skipping main idea generation and full codebase update.")
+                return {
+                    "result": "Docstrings successfully generated (incremental)",
+                    "events": self.events,
+                }
 
             # generate the main idea
             await self.dg.generate_the_main_idea(res)

--- a/osa_tool/operations/codebase/docstring_generation/docstring_generation.py
+++ b/osa_tool/operations/codebase/docstring_generation/docstring_generation.py
@@ -29,8 +29,13 @@ class DocstringsGenerator:
         self.repo_path = parse_folder_name(self.repo_url)
 
         self.dg = DocGen(self.config_manager)
-        self.ts = OSA_TreeSitter(self.repo_path, self.ignore_list, target_files=self.target_files, )
+        self.ts = OSA_TreeSitter(
+            self.repo_path,
+            self.ignore_list,
+            target_files=self.target_files,
+        )
         self.events: list[OperationEvent] = []
+
     def run(self) -> dict:
         """
         Sync entrypoint without explicit loop.

--- a/osa_tool/operations/codebase/docstring_generation/osa_treesitter.py
+++ b/osa_tool/operations/codebase/docstring_generation/osa_treesitter.py
@@ -649,7 +649,7 @@ class OSA_TreeSitter(object):
                     arguments.append(param_node.text.decode("utf-8"))
 
         source_bytes = source_code.encode("utf-8")
-        source = source_bytes[function_node.start_byte : node.end_byte].decode("utf-8")
+        source = source_bytes[function_node.start_byte : function_node.end_byte].decode("utf-8")
 
         return_node = function_node.child_by_field_name("return_type")
         return_type = None

--- a/osa_tool/operations/codebase/docstring_generation/osa_treesitter.py
+++ b/osa_tool/operations/codebase/docstring_generation/osa_treesitter.py
@@ -48,7 +48,9 @@ class OSA_TreeSitter(object):
         """
         script_files = []
 
-        if self.target_files:
+        print(self.target_files)
+
+        if self.target_files is not None:
             for file_path in self.target_files:
                 p = Path(os.path.join(self.cwd, file_path)).resolve()
                 if p.exists() and str(p).endswith(".py") and not self._is_ignored(p) and p.name not in self.ignore_list:

--- a/osa_tool/operations/codebase/docstring_generation/osa_treesitter.py
+++ b/osa_tool/operations/codebase/docstring_generation/osa_treesitter.py
@@ -48,9 +48,7 @@ class OSA_TreeSitter(object):
         """
         script_files = []
 
-        print(self.target_files)
-
-        if self.target_files is not None:
+        if self.target_files:
             for file_path in self.target_files:
                 p = Path(os.path.join(self.cwd, file_path)).resolve()
                 if p.exists() and str(p).endswith(".py") and not self._is_ignored(p) and p.name not in self.ignore_list:

--- a/osa_tool/operations/codebase/docstring_generation/osa_treesitter.py
+++ b/osa_tool/operations/codebase/docstring_generation/osa_treesitter.py
@@ -14,11 +14,13 @@ class OSA_TreeSitter(object):
         cwd: A current working directory with source code files.
     """
 
-    def __init__(self, scripts_path: str, ignore_list: list[str] = None):
+    def __init__(self, scripts_path: str, ignore_list: list[str] = None, target_files: list[str] = None):
         """Initialization of the instance based on the provided path to the scripts.
 
         Args:
             scripts_path: provided by user path to the scripts.
+            ignore_list: files that will be ignored.
+            target_files: files that need to be checked.
         """
         self.cwd = scripts_path
         self.import_map = {}
@@ -26,6 +28,7 @@ class OSA_TreeSitter(object):
             self.ignore_list = ignore_list
         else:
             self.ignore_list = ["__init__.py"]
+        self.target_files = target_files
 
     def files_list(self, path: str) -> tuple[list, 0] | tuple[list[str], 1]:
         """Method provides a list of files occurring in the provided path.
@@ -44,6 +47,13 @@ class OSA_TreeSitter(object):
             1 - a path to the specific file was provided.
         """
         script_files = []
+
+        if self.target_files:
+            for file_path in self.target_files:
+                p = Path(os.path.join(self.cwd, file_path)).resolve()
+                if p.exists() and str(p).endswith(".py") and not self._is_ignored(p) and p.name not in self.ignore_list:
+                    script_files.append(str(p))
+            return script_files, 0
 
         if os.path.isdir(path):
             for root, _, files in os.walk(path):

--- a/osa_tool/operations/codebase/docstring_generation/topology.py
+++ b/osa_tool/operations/codebase/docstring_generation/topology.py
@@ -72,7 +72,7 @@ class DependencyGraph:
                 dependency_node = self._resolve_call(node_id, call)
 
                 if dependency_node and dependency_node in self.nodes:
-                    if node_id != dependency_node: # Avoiding self-recursion
+                    if node_id != dependency_node:  # Avoiding self-recursion
                         self.graph[node_id].add(dependency_node)
                         self.reverse_graph[dependency_node].add(node_id)
                     else:

--- a/osa_tool/operations/codebase/docstring_generation/topology.py
+++ b/osa_tool/operations/codebase/docstring_generation/topology.py
@@ -72,8 +72,11 @@ class DependencyGraph:
                 dependency_node = self._resolve_call(node_id, call)
 
                 if dependency_node and dependency_node in self.nodes:
-                    self.graph[node_id].add(dependency_node)
-                    self.reverse_graph[dependency_node].add(node_id)
+                    if node_id != dependency_node: # Avoiding self-recursion
+                        self.graph[node_id].add(dependency_node)
+                        self.reverse_graph[dependency_node].add(node_id)
+                    else:
+                        logger.debug(f"Skipping self-recursion for node {node_id}")
 
     def _resolve_call(self, caller_node_id: str, call_name: str) -> str:
         """

--- a/osa_tool/operations/codebase/requirements_generation/requirements_generation.py
+++ b/osa_tool/operations/codebase/requirements_generation/requirements_generation.py
@@ -28,7 +28,8 @@ class RequirementsGenerator:
         self.repo_path = Path(parse_folder_name(self.repo_url)).resolve()
         self.events: list[OperationEvent] = []
         self.prompts = self.config_manager.get_prompts()
-        self.model_handler = ModelHandlerFactory.build(self.config_manager.config)
+        self.model_settings = self.config_manager.get_model_settings("general")
+        self.model_handler = ModelHandlerFactory.build(self.model_settings)
 
     def generate(self) -> dict:
         logger.info(f"Starting the generation of requirements for: {self.repo_url}")

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -261,6 +261,7 @@ def main():
 
 def initialize_git_platform(args) -> tuple[GitAgent, WorkflowManager]:
 <<<<<<< HEAD
+<<<<<<< HEAD
     is_ci = os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
     is_incremental = getattr(args, "incremental", False)
     no_remote = args.no_pull_request and args.no_fork
@@ -275,6 +276,9 @@ def initialize_git_platform(args) -> tuple[GitAgent, WorkflowManager]:
     logger.info(f"Target branch set to: '{target_branch}'")
 =======
     if os.getenv("GITHUB_ACTIONS") == "true":
+=======
+    if os.getenv("GITHUB_ACTIONS").lower() == "true":
+>>>>>>> 4d1899c (fixes)
         target_branch = args.branch
     else:
         target_branch = "osa_tool"

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -140,7 +140,6 @@ def main():
                 lambda: DocstringsGenerator(
                     config_manager=config_manager,
                     ignore_list=args.ignore_list,
-                    plan=plan,
                     incremental=args.incremental,
                     target_files=args.target_files,
                 ).run(),

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -256,7 +256,7 @@ def main():
 
 
 def initialize_git_platform(args, config_manager: ConfigManager) -> tuple[GitAgent, WorkflowManager]:
-    if os.getenv("GITHUB_ACTIONS").lower() == "true":
+    if (os.getenv("GITHUB_ACTIONS") is not None) and (os.getenv("GITHUB_ACTIONS").lower() == "true"):
         target_branch = args.branch
     else:
         target_branch = config_manager.config.osa_branch_name

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -260,6 +260,7 @@ def main():
 
 
 def initialize_git_platform(args) -> tuple[GitAgent, WorkflowManager]:
+<<<<<<< HEAD
     is_ci = os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
     is_incremental = getattr(args, "incremental", False)
     no_remote = args.no_pull_request and args.no_fork
@@ -272,15 +273,30 @@ def initialize_git_platform(args) -> tuple[GitAgent, WorkflowManager]:
         target_branch = getattr(config_manager.config.git, "osa_branch_name", "osa_tool")
 
     logger.info(f"Target branch set to: '{target_branch}'")
+=======
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        target_branch = args.branch
+    else:
+        target_branch = "osa_tool"
+>>>>>>> 0951082 (ci_cd branch)
 
     if "github.com" in args.repository:
-        git_agent = GitHubAgent(args.repository, args.branch, author=args.author)
+        git_agent = GitHubAgent(args.repository,
+                                repo_branch_name=args.branch,
+                                branch_name=target_branch,
+                                author=args.author)
         workflow_manager = GitHubWorkflowManager(args.repository, git_agent.metadata, args)
     elif "gitlab." in args.repository:
-        git_agent = GitLabAgent(args.repository, args.branch, author=args.author)
+        git_agent = GitLabAgent(args.repository,
+                                repo_branch_name=args.branch,
+                                branch_name=target_branch,
+                                author=args.author)
         workflow_manager = GitLabWorkflowManager(args.repository, git_agent.metadata, args)
     elif "gitverse.ru" in args.repository:
-        git_agent = GitverseAgent(args.repository, args.branch, author=args.author)
+        git_agent = GitverseAgent(args.repository,
+                                  repo_branch_name=args.branch,
+                                  branch_name=target_branch,
+                                  author=args.author)
         workflow_manager = GitverseWorkflowManager(args.repository, git_agent.metadata, args)
     else:
         raise ValueError(f"Cannot initialize Git Agent and Workflow Manager for this platform: {args.repository}")

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -281,22 +281,19 @@ def initialize_git_platform(args) -> tuple[GitAgent, WorkflowManager]:
 >>>>>>> 0951082 (ci_cd branch)
 
     if "github.com" in args.repository:
-        git_agent = GitHubAgent(args.repository,
-                                repo_branch_name=args.branch,
-                                branch_name=target_branch,
-                                author=args.author)
+        git_agent = GitHubAgent(
+            args.repository, repo_branch_name=args.branch, branch_name=target_branch, author=args.author
+        )
         workflow_manager = GitHubWorkflowManager(args.repository, git_agent.metadata, args)
     elif "gitlab." in args.repository:
-        git_agent = GitLabAgent(args.repository,
-                                repo_branch_name=args.branch,
-                                branch_name=target_branch,
-                                author=args.author)
+        git_agent = GitLabAgent(
+            args.repository, repo_branch_name=args.branch, branch_name=target_branch, author=args.author
+        )
         workflow_manager = GitLabWorkflowManager(args.repository, git_agent.metadata, args)
     elif "gitverse.ru" in args.repository:
-        git_agent = GitverseAgent(args.repository,
-                                  repo_branch_name=args.branch,
-                                  branch_name=target_branch,
-                                  author=args.author)
+        git_agent = GitverseAgent(
+            args.repository, repo_branch_name=args.branch, branch_name=target_branch, author=args.author
+        )
         workflow_manager = GitverseWorkflowManager(args.repository, git_agent.metadata, args)
     else:
         raise ValueError(f"Cannot initialize Git Agent and Workflow Manager for this platform: {args.repository}")

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -1,17 +1,14 @@
+import asyncio
 import os
 import sys
 import time
-from typing import Any, Callable
 
 from osa_tool.config.settings import ConfigManager
+from osa_tool.conversion.notebook_converter import NotebookConverter
 from osa_tool.core.git.git_agent import GitHubAgent, GitLabAgent, GitverseAgent, GitAgent
 from osa_tool.operations.analysis.repository_report.report_maker import ReportGenerator, WhatHasBeenDoneReportGenerator
-from osa_tool.operations.analysis.repository_validation.doc_validator import DocValidator
-from osa_tool.operations.analysis.repository_validation.paper_validator import PaperValidator
 from osa_tool.operations.codebase.directory_translation.dirs_and_files_translator import RepositoryStructureTranslator
 from osa_tool.operations.codebase.docstring_generation.docstring_generation import DocstringsGenerator
-from osa_tool.operations.codebase.notebook_conversion.notebook_converter import NotebookConverter
-from osa_tool.operations.codebase.organization.repo_organizer import RepoOrganizer
 from osa_tool.operations.codebase.requirements_generation.requirements_generation import RequirementsGenerator
 from osa_tool.operations.docs.about_generation.about_generator import AboutGenerator
 from osa_tool.tools.repository_analysis.sourcerank import SourceRank
@@ -22,7 +19,7 @@ from osa_tool.operations.docs.community_docs_generation.docs_run import generate
 from osa_tool.operations.docs.community_docs_generation.license_generation import LicenseCompiler
 from osa_tool.operations.docs.readme_generation.readme_agent import ReadmeAgent
 from osa_tool.operations.docs.readme_translation.readme_translator import ReadmeTranslator
-from osa_tool.scheduler.plan import Plan
+from osa_tool.organization.repo_organizer import RepoOrganizer
 from osa_tool.scheduler.scheduler import ModeScheduler
 from osa_tool.scheduler.workflow_manager import (
     GitHubWorkflowManager,
@@ -75,7 +72,7 @@ def main():
         config_manager = ConfigManager(args)
 
         # Initialize Git agent and Workflow Manager for used platform, perform operations
-        git_agent, workflow_manager = initialize_git_platform(args, config_manager)
+        git_agent, workflow_manager = initialize_git_platform(args)
 
         if create_fork:
             git_agent.star_repository()
@@ -142,8 +139,7 @@ def main():
             _run_plan_operation(
                 plan,
                 "docstring",
-                lambda:
-                DocstringsGenerator(
+                lambda: DocstringsGenerator(
                     config_manager=config_manager,
                     ignore_list=args.ignore_list,
                     plan=plan,
@@ -260,31 +256,10 @@ def main():
 
 
 def initialize_git_platform(args) -> tuple[GitAgent, WorkflowManager]:
-<<<<<<< HEAD
-<<<<<<< HEAD
-    is_ci = os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
-    is_incremental = getattr(args, "incremental", False)
-    no_remote = args.no_pull_request and args.no_fork
-
-    logger.info(f"[Branch Selection] CI={is_ci}, Incremental={is_incremental}, NoRemote={no_remote}. Args branch: {args.branch}")
-
-    if is_ci or is_incremental or no_remote:
-        target_branch = args.branch
-    else:
-        target_branch = getattr(config_manager.config.git, "osa_branch_name", "osa_tool")
-
-    logger.info(f"Target branch set to: '{target_branch}'")
-=======
-    if os.getenv("GITHUB_ACTIONS") == "true":
-=======
     if os.getenv("GITHUB_ACTIONS").lower() == "true":
->>>>>>> 4d1899c (fixes)
         target_branch = args.branch
     else:
         target_branch = "osa_tool"
->>>>>>> 0951082 (ci_cd branch)
-
-    logger.info(f"[Branch Selection] CI={os.getenv('GITHUB_ACTIONS')}, Args branch: {args.branch}")
 
     if "github.com" in args.repository:
         git_agent = GitHubAgent(

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -40,6 +40,11 @@ from osa_tool.utils.utils import (
     switch_to_output_directory,
     format_time,
 )
+from osa_tool.validation.doc_validator import DocValidator
+from osa_tool.validation.paper_validator import PaperValidator
+from osa_tool.validation.report_generator import (
+    ReportGenerator as ValidationReportGenerator,
+)
 
 
 def main():
@@ -70,7 +75,7 @@ def main():
         config_manager = ConfigManager(args)
 
         # Initialize Git agent and Workflow Manager for used platform, perform operations
-        git_agent, workflow_manager = initialize_git_platform(args)
+        git_agent, workflow_manager = initialize_git_platform(args, config_manager)
 
         if create_fork:
             git_agent.star_repository()
@@ -137,7 +142,14 @@ def main():
             _run_plan_operation(
                 plan,
                 "docstring",
-                lambda: DocstringsGenerator(config_manager, args.ignore_list).run(),
+                lambda:
+                DocstringsGenerator(
+                    config_manager=config_manager,
+                    ignore_list=args.ignore_list,
+                    plan=plan,
+                    incremental=args.incremental,
+                    target_files=args.target_files,
+                ).run(),
             )
 
         # License compiling
@@ -248,6 +260,19 @@ def main():
 
 
 def initialize_git_platform(args) -> tuple[GitAgent, WorkflowManager]:
+    is_ci = os.getenv("GITHUB_ACTIONS", "false").lower() == "true"
+    is_incremental = getattr(args, "incremental", False)
+    no_remote = args.no_pull_request and args.no_fork
+
+    logger.info(f"[Branch Selection] CI={is_ci}, Incremental={is_incremental}, NoRemote={no_remote}. Args branch: {args.branch}")
+
+    if is_ci or is_incremental or no_remote:
+        target_branch = args.branch
+    else:
+        target_branch = getattr(config_manager.config.git, "osa_branch_name", "osa_tool")
+
+    logger.info(f"Target branch set to: '{target_branch}'")
+
     if "github.com" in args.repository:
         git_agent = GitHubAgent(args.repository, args.branch, author=args.author)
         workflow_manager = GitHubWorkflowManager(args.repository, git_agent.metadata, args)

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -1,14 +1,17 @@
-import asyncio
 import os
 import sys
 import time
+from typing import Any, Callable
 
 from osa_tool.config.settings import ConfigManager
-from osa_tool.conversion.notebook_converter import NotebookConverter
 from osa_tool.core.git.git_agent import GitHubAgent, GitLabAgent, GitverseAgent, GitAgent
 from osa_tool.operations.analysis.repository_report.report_maker import ReportGenerator, WhatHasBeenDoneReportGenerator
+from osa_tool.operations.analysis.repository_validation.doc_validator import DocValidator
+from osa_tool.operations.analysis.repository_validation.paper_validator import PaperValidator
 from osa_tool.operations.codebase.directory_translation.dirs_and_files_translator import RepositoryStructureTranslator
 from osa_tool.operations.codebase.docstring_generation.docstring_generation import DocstringsGenerator
+from osa_tool.operations.codebase.notebook_conversion.notebook_converter import NotebookConverter
+from osa_tool.operations.codebase.organization.repo_organizer import RepoOrganizer
 from osa_tool.operations.codebase.requirements_generation.requirements_generation import RequirementsGenerator
 from osa_tool.operations.docs.about_generation.about_generator import AboutGenerator
 from osa_tool.tools.repository_analysis.sourcerank import SourceRank
@@ -19,7 +22,7 @@ from osa_tool.operations.docs.community_docs_generation.docs_run import generate
 from osa_tool.operations.docs.community_docs_generation.license_generation import LicenseCompiler
 from osa_tool.operations.docs.readme_generation.readme_agent import ReadmeAgent
 from osa_tool.operations.docs.readme_translation.readme_translator import ReadmeTranslator
-from osa_tool.organization.repo_organizer import RepoOrganizer
+from osa_tool.scheduler.plan import Plan
 from osa_tool.scheduler.scheduler import ModeScheduler
 from osa_tool.scheduler.workflow_manager import (
     GitHubWorkflowManager,
@@ -36,11 +39,6 @@ from osa_tool.utils.utils import (
     rich_section,
     switch_to_output_directory,
     format_time,
-)
-from osa_tool.validation.doc_validator import DocValidator
-from osa_tool.validation.paper_validator import PaperValidator
-from osa_tool.validation.report_generator import (
-    ReportGenerator as ValidationReportGenerator,
 )
 
 

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -72,7 +72,7 @@ def main():
         config_manager = ConfigManager(args)
 
         # Initialize Git agent and Workflow Manager for used platform, perform operations
-        git_agent, workflow_manager = initialize_git_platform(args)
+        git_agent, workflow_manager = initialize_git_platform(args, config_manager)
 
         if create_fork:
             git_agent.star_repository()
@@ -255,11 +255,11 @@ def main():
         sys.exit(1)
 
 
-def initialize_git_platform(args) -> tuple[GitAgent, WorkflowManager]:
+def initialize_git_platform(args, config_manager: ConfigManager) -> tuple[GitAgent, WorkflowManager]:
     if os.getenv("GITHUB_ACTIONS").lower() == "true":
         target_branch = args.branch
     else:
-        target_branch = GitAgent.DEFAULT_BRANCH_NAME
+        target_branch = config_manager.config.osa_branch_name
 
     if "github.com" in args.repository:
         git_agent = GitHubAgent(

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -259,7 +259,7 @@ def initialize_git_platform(args) -> tuple[GitAgent, WorkflowManager]:
     if os.getenv("GITHUB_ACTIONS").lower() == "true":
         target_branch = args.branch
     else:
-        target_branch = "osa_tool"
+        target_branch = GitAgent.DEFAULT_BRANCH_NAME
 
     if "github.com" in args.repository:
         git_agent = GitHubAgent(

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -259,7 +259,7 @@ def initialize_git_platform(args, config_manager: ConfigManager) -> tuple[GitAge
     if (os.getenv("GITHUB_ACTIONS") is not None) and (os.getenv("GITHUB_ACTIONS").lower() == "true"):
         target_branch = args.branch
     else:
-        target_branch = config_manager.config.osa_branch_name
+        target_branch = getattr(config_manager.config.git, "osa_branch_name", "osa_tool")
 
     if "github.com" in args.repository:
         git_agent = GitHubAgent(

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -284,6 +284,8 @@ def initialize_git_platform(args) -> tuple[GitAgent, WorkflowManager]:
         target_branch = "osa_tool"
 >>>>>>> 0951082 (ci_cd branch)
 
+    logger.info(f"[Branch Selection] CI={os.getenv('GITHUB_ACTIONS')}, Args branch: {args.branch}")
+
     if "github.com" in args.repository:
         git_agent = GitHubAgent(
             args.repository, repo_branch_name=args.branch, branch_name=target_branch, author=args.author

--- a/tests/unit/operations/codebase/docstring_generation/test_docgen.py
+++ b/tests/unit/operations/codebase/docstring_generation/test_docgen.py
@@ -476,31 +476,31 @@ def test_insert_docstring_in_code(mock_config_manager, source, method_details, n
     [
         # Case 1: Common function (Linux style \n)
         (
-                "def foo(x):\n    return x + 1\n",
-                {"source_code": "def foo(x):\n    return x + 1\n", "method_name": "foo"},
-                '"""Adds one"""',
-                "Adds one",
+            "def foo(x):\n    return x + 1\n",
+            {"source_code": "def foo(x):\n    return x + 1\n", "method_name": "foo"},
+            '"""Adds one"""',
+            "Adds one",
         ),
         # Case 2: Common function (Windows style \r\n)
         (
-                "def foo(x):\r\n    return x + 1\r\n",
-                {"source_code": "def foo(x):\r\n    return x + 1\r\n", "method_name": "foo"},
-                '"""Adds one"""',
-                "Adds one",
+            "def foo(x):\r\n    return x + 1\r\n",
+            {"source_code": "def foo(x):\r\n    return x + 1\r\n", "method_name": "foo"},
+            '"""Adds one"""',
+            "Adds one",
         ),
         # Case 3: Changing old docstring
         (
-                'def bar(y):\n    """Old doc"""\n    return y * 2\n',
-                {"source_code": 'def bar(y):\n    """Old doc"""\n    return y * 2\n', "method_name": "bar"},
-                '"""Multiply by two"""',
-                "Multiply by two",
+            'def bar(y):\n    """Old doc"""\n    return y * 2\n',
+            {"source_code": 'def bar(y):\n    """Old doc"""\n    return y * 2\n', "method_name": "bar"},
+            '"""Multiply by two"""',
+            "Multiply by two",
         ),
         # Case 4: Async function
         (
-                "async def baz(z):\n    return z - 1\n",
-                {"source_code": "async def baz(z):\n    return z - 1\n", "method_name": "baz"},
-                '"""Subtract one"""',
-                "Subtract one",
+            "async def baz(z):\n    return z - 1\n",
+            {"source_code": "async def baz(z):\n    return z - 1\n", "method_name": "baz"},
+            '"""Subtract one"""',
+            "Subtract one",
         ),
     ],
 )

--- a/tests/unit/operations/codebase/docstring_generation/test_docgen.py
+++ b/tests/unit/operations/codebase/docstring_generation/test_docgen.py
@@ -472,29 +472,39 @@ def test_insert_docstring_in_code(mock_config_manager, source, method_details, n
 
 
 @pytest.mark.parametrize(
-    "source, class_name, new_doc, expected_snippet",
+    "source, method_details, new_doc, expected_content",
     [
+        # Case 1: Common function (Linux style \n)
         (
-            "class MyClass:\n    pass\n",
-            "MyClass",
-            '"""This is a class"""',
-            '"""\n    This is a class\n    """',
+                "def foo(x):\n    return x + 1\n",
+                {"source_code": "def foo(x):\n    return x + 1\n", "method_name": "foo"},
+                '"""Adds one"""',
+                "Adds one",
         ),
+        # Case 2: Common function (Windows style \r\n)
         (
-            'class OldClass:\n    """Old docstring"""\n    pass\n',
-            "OldClass",
-            '"""Updated docstring"""',
-            '"""\n    Updated docstring\n    """',
+                "def foo(x):\r\n    return x + 1\r\n",
+                {"source_code": "def foo(x):\r\n    return x + 1\r\n", "method_name": "foo"},
+                '"""Adds one"""',
+                "Adds one",
         ),
+        # Case 3: Changing old docstring
         (
-            "class ParamClass(Base):\n    pass\n",
-            "ParamClass",
-            '"""Class with base"""',
-            '"""\n    Class with base\n    """',
+                'def bar(y):\n    """Old doc"""\n    return y * 2\n',
+                {"source_code": 'def bar(y):\n    """Old doc"""\n    return y * 2\n', "method_name": "bar"},
+                '"""Multiply by two"""',
+                "Multiply by two",
+        ),
+        # Case 4: Async function
+        (
+                "async def baz(z):\n    return z - 1\n",
+                {"source_code": "async def baz(z):\n    return z - 1\n", "method_name": "baz"},
+                '"""Subtract one"""',
+                "Subtract one",
         ),
     ],
 )
-def test_insert_docstring_in_code(mock_config_manager, source, method_details, new_doc, expected_snippet):
+def test_insert_docstring_in_code(mock_config_manager, source, method_details, new_doc, expected_content):
     # Arrange
     docgen = DocGen(mock_config_manager)
 
@@ -502,16 +512,19 @@ def test_insert_docstring_in_code(mock_config_manager, source, method_details, n
     updated = docgen.insert_docstring_in_code(source, method_details, new_doc)
 
     # Assert
-    assert updated != source
+    assert updated != source, "Source code should be modified"
 
-    clean_doc_content = expected_snippet.strip('"')
-    assert clean_doc_content in updated
+    assert expected_content in updated, "New docstring content not found in updated code"
 
-    assert "def " in updated
+    if "async def" in source:
+        assert "async def " in updated
+    else:
+        assert "def " in updated
+
     assert "return " in updated
 
     if '"""Old doc"""' in source:
-        assert '"""Old doc"""' not in updated
+        assert '"""Old doc"""' not in updated, "Old docstring was not removed"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/operations/codebase/docstring_generation/test_docgen.py
+++ b/tests/unit/operations/codebase/docstring_generation/test_docgen.py
@@ -494,15 +494,24 @@ def test_insert_docstring_in_code(mock_config_manager, source, method_details, n
         ),
     ],
 )
-def test_insert_cls_docstring_in_code(mock_config_manager, source, class_name, new_doc, expected_snippet):
+def test_insert_docstring_in_code(mock_config_manager, source, method_details, new_doc, expected_snippet):
     # Arrange
     docgen = DocGen(mock_config_manager)
 
     # Act
-    updated = docgen.insert_cls_docstring_in_code(source, class_name, new_doc)
+    updated = docgen.insert_docstring_in_code(source, method_details, new_doc)
 
     # Assert
-    assert expected_snippet in updated
+    assert updated != source
+
+    clean_doc_content = expected_snippet.strip('"')
+    assert clean_doc_content in updated
+
+    assert "def " in updated
+    assert "return " in updated
+
+    if '"""Old doc"""' in source:
+        assert '"""Old doc"""' not in updated
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Изменения в PR:

### CI/CD:
- Добавлен файл action.yml. Теперь OSA - это Composite Action. OSA можно подключить к любому репозиторию одной строчкой в workflow. Он сам поставит зависимости и запустит анализ. При каждом коммите в ветке - дополняет новые функции, в которых нет док-стрингов.
- Добавлен флаг `--incremental` - в нём OSA не переписывает весь проект, а только заполняет пустые докстринги, которых не хватает.
- Добавлен флаг `--target-files` - позволяет передать список файлов для анализа. В контексте Actions позволяет передавать только те файлы, которые изменились, а не весь репозиторий.
- В run.py добавлена проверка на GITHUB_ACTIONS, если OSA видит что она в CI режиме, то она автоматически работает с текущей веткой PR, а не стандартной osa_tool (чтобы не возникло конфликтов).

### Багфиксы:
- Юнит тесты проверяли, что код НЕ меняется, хотя должен был? Дополнил юнит тесты на корректную логику. 
- Раньше рекурсивные функции (вызывающие сами себя) создавали циклическую зависимость в графе и просто игнорировались. Теперь саморекурсия игнорируется.
-  Починил баг с вставкой кода, когда из-за разницы переносов строк (\n в Linux и \r\n в Windows) OSA не могла найти место для вставки и отдавала пустой результат.
- Почему-то поиск через регулярки порой просто не находил функцию + не находились функции, если в конце объявления был комментарий. 

### Пример вызова в workflow:

```
- name: Run OSA Action
  uses: aimclub/OSA@main # Или @feature/ci_cd_mode пока не замержено
  with:
    openai_api_key: ${{ secrets.OPENAI_API_KEY }}
    api: 'openai'
    base_url: 'https://openrouter.ai/api/v1'
    model: 'openai/gpt-4o'
```
Для работы нужно добавить в Secrets репозитория токен провайдера, поддерживает всех из которых поддерживает OSA. Но если будем добавлять провайдеров - нужно будет дополнять логику.

Пайплайн работы представлен в комменте внизу.
