### PR TITLE
feature/sourcecraft integration

### DIFF
--- a/osa_tool/config/prompts/readme/prompts.toml
+++ b/osa_tool/config/prompts/readme/prompts.toml
@@ -93,6 +93,7 @@ RULES:
 - Distinguish strong evidence from weak hints (use cautious wording when uncertain).
 - Prefer concrete observations over generic statements.
 - Keep the output compact and scannable.
+- When mentioning how to clone the repository, always use the provided CLONE URL, not any URL inferred from the repository tree or README.
 
 INPUT DATA:
 
@@ -107,6 +108,10 @@ INPUT DATA:
 3. EXISTING README:
 
 {existing_readme}
+
+4. CLONE URL:
+
+{clone_url_http}
 """
 
 readme_analysis = """

--- a/osa_tool/config/templates/template.toml
+++ b/osa_tool/config/templates/template.toml
@@ -140,9 +140,9 @@ If you use this software, please cite it as below.
 
         journal = {{{publisher} repository}},
 
-        howpublished = {{\\url{{{repository_url}.git}}}},
+        howpublished = {{\\url{{{repository_url}}}}},
 
-        url = {{{repository_url}.git}}
+        url = {{{repository_url}}}
 
     }}
 

--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -1403,12 +1403,13 @@ class GitverseAgent(GitAgent):
 
 
 class SourceCraftAgent(GitAgent):
-    API_BASE = "https://api.sourcecraft.dev" 
+    API_BASE = "https://api.sourcecraft.dev" # Или актуальный домен API
 
     def _get_token(self) -> str:
         return os.getenv("SOURCECRAFT_TOKEN", os.getenv("GIT_TOKEN", ""))
 
     def _load_metadata(self, repo_url: str) -> RepositoryMetadata:
+        from osa_tool.core.git.metadata import SourceCraftMetadataLoader
         return SourceCraftMetadataLoader.load_data(repo_url)
 
     def _get_headers(self) -> dict:
@@ -1420,11 +1421,10 @@ class SourceCraftAgent(GitAgent):
         }
 
     def _extract_slugs(self) -> tuple[str, str]:
-        """Извлекает org_slug и repo_slug из URL (например, https://sourcecraft.dev/Yandex/OSA)"""
-        # Убираем .git если есть
+        """Извлекает org_slug и repo_slug из URL"""
         clean_url = self.repo_url[:-4] if self.repo_url.endswith('.git') else self.repo_url
         parts = clean_url.strip("/").split("/")
-        return parts[-2], parts[-1]  # org_slug, repo_slug
+        return parts[-2], parts[-1]
 
     def create_fork(self) -> None:
         if not self.token:
@@ -1432,36 +1432,40 @@ class SourceCraftAgent(GitAgent):
 
         org_slug, repo_slug = self._extract_slugs()
         
-        # узнаем свой username чтобы понять куда форкать
+        # Получаем профиль текущего пользователя
         user_response = requests.get(f"{self.API_BASE}/user", headers=self._get_headers())
         if user_response.status_code != 200:
              self._handle_api_error(user_response, "getting SourceCraft user profile", raise_exception=True)
+
+        bot_username = user_response.json().get("username", "") if user_response.status_code == 200 else ""
              
         current_username = user_response.json().get("username")
 
-        # если мы уже владеем репо - форк не нужен
         if org_slug == current_username:
             self.fork_url = self.repo_url
             logger.info(f"User '{current_username}' already owns the repository. Using original URL.")
             return
 
-        # Делаем форк
+        # ИСПРАВЛЕНО СОГЛАСНО SWAGGER: Передаем org_slug и default_branch_only
         url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}/fork"
         body = {
-            "org_slug": current_username, # Форкаем к себе
+            "org_slug": current_username,
+            "default_branch_only": True
         }
         
         response = requests.post(url, headers=self._get_headers(), json=body)
         
         if response.status_code in {200, 201, 202}:
-            # Из Swagger: возвращается объект Repository, у которого есть web_url
-            self.fork_url = response.json().get("web_url", f"https://sourcecraft.dev/{current_username}/{repo_slug}")
+            repo_data = response.json()
+            self.fork_url = repo_data.get("web_url", f"https://sourcecraft.dev/{current_username}/{repo_slug}")
+            # ИСПРАВЛЕНО: Сохраняем ID форка для создания PR
+            self.fork_id = repo_data.get("id")
             logger.info(f"SourceCraft fork created successfully: {self.fork_url}")
         else:
             self._handle_api_error(response, "creating SourceCraft fork", raise_exception=True)
 
     def star_repository(self) -> None:
-        # В Swagger нет эндпоинта для звезд. 
+        # В Swagger действительно нет эндпоинта для постановки звезд.
         logger.warning("Starring repositories is not supported via SourceCraft public API yet.")
 
     def create_pull_request(self, title: str = None, body: str = None, changes: bool = False) -> None:
@@ -1469,11 +1473,6 @@ class SourceCraftAgent(GitAgent):
             raise ValueError("SourceCraft token is required to create a pull request.")
 
         org_slug, repo_slug = self._extract_slugs()
-        fork_org, _ = self.fork_url.strip("/").split("/")[-2:]
-        
-        # На SourceCraft ветка форка указывается в формате: fork_owner:branch
-        head_branch = f"{fork_org}:{self.branch_name}"
-        
         url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}/pulls"
         headers = self._get_headers()
 
@@ -1481,15 +1480,18 @@ class SourceCraftAgent(GitAgent):
         pr_title = title if title else last_commit
         pr_body = (body if body else "") + self.agent_signature
 
-        # Ищем существующие PR
-        params = {"state": "open", "source_branch": head_branch, "target_branch": self.base_branch}
+        # ИСПРАВЛЕНО СОГЛАСНО SWAGGER: Использование QL фильтра для поиска PR
+        ql_filter = f'status=open and source_branch="{self.branch_name}" and target_branch="{self.base_branch}"'
+        if bot_username:
+            ql_filter += f' and author_slug="{bot_username}"'
+        params = {"filter": ql_filter}
+        
         list_response = requests.get(url, headers=headers, params=params)
-
         prs = list_response.json().get("pull_requests",[]) if list_response.status_code == 200 else []
 
         if prs:
             existing_pr = prs[0]
-            pr_slug = existing_pr["slug"]
+            pr_slug = existing_pr.get("slug")
             logger.info(f"Pull request {pr_slug} already exists.")
             
             # Обновление PR
@@ -1503,13 +1505,19 @@ class SourceCraftAgent(GitAgent):
                 self._handle_api_error(update_res, f"updating PR {pr_slug}", raise_exception=False)
                 
         elif changes:
-            # Создание нового PR
+            # ВАЖНО:
+            # Если PR создается из форка, то source_branch в фильтре может нуждаться в указании пространства имен (например, fork_owner:branch), как в GitHub. Swagger об этом умалчивает.
+            # Если при тестировании поиск существующего PR сломается (будет создавать дубликаты), то фильтр нужно будет уточнить (возможно, добавив author_slug).
             pr_data = {
                 "title": pr_title,
                 "description": pr_body,
-                "source_branch": head_branch,
-                "target_branch": self.base_branch
+                "source_branch": self.branch_name,
+                "target_branch": self.base_branch,
+                "publish": True  # Чтобы PR не остался в статусе Draft
             }
+            
+            if hasattr(self, 'fork_id') and self.fork_id:
+                pr_data["fork_repo_id"] = self.fork_id
 
             response = requests.post(url, json=pr_data, headers=headers)
             if response.status_code == 201:
@@ -1522,6 +1530,7 @@ class SourceCraftAgent(GitAgent):
         parts = repo_path.strip("/").split("/")
         org_slug, repo_slug = parts[-2], parts[-1]
         
+        # Согласно Swagger, UpdateRepositoryBody принимает description
         url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}"
         about_data = {
             "description": about_content.get("description", "")
@@ -1537,14 +1546,13 @@ class SourceCraftAgent(GitAgent):
         return f"{self.fork_url}/tree/{report_branch}/{report_filename}"
 
     def _build_auth_url(self, repo_url: str) -> str:
-        # Для SourceCraft обычно так же, как в GitHub
         import re
         match = re.match(r"https?://([^/]+)/(.+)", repo_url)
         if match:
             host = match.group(1)
             path = match.group(2)
-            # Вставляем токен перед хостом
-            return f"https://oauth2:{self.token}@{host}/{path}.git"
+            # Используем токен как username для HTTP basic auth
+            return f"https://{self.token}@{host}/{path}.git"
         raise ValueError(f"Unsupported repository URL format for SourceCraft: {repo_url}")
 
     def validate_topics(self, topics: list[str]) -> list[str]:

--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -12,6 +12,7 @@ from osa_tool.core.git.metadata import (
     GitHubMetadataLoader,
     GitLabMetadataLoader,
     GitverseMetadataLoader,
+    SourceCraftMetadataLoader, 
     RepositoryMetadata,
 )
 from osa_tool.utils.logger import logger
@@ -1398,4 +1399,154 @@ class GitverseAgent(GitAgent):
 
     def validate_topics(self, topics: List[str]) -> List[str]:
         logger.warning("Topic validation is not yet implemented for Gitverse. Returning original topics list.")
+        return topics
+
+
+class SourceCraftAgent(GitAgent):
+    API_BASE = "https://api.sourcecraft.dev" 
+
+    def _get_token(self) -> str:
+        return os.getenv("SOURCECRAFT_TOKEN", os.getenv("GIT_TOKEN", ""))
+
+    def _load_metadata(self, repo_url: str) -> RepositoryMetadata:
+        return SourceCraftMetadataLoader.load_data(repo_url)
+
+    def _get_headers(self) -> dict:
+        """Вспомогательный метод для генерации заголовков"""
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def _extract_slugs(self) -> tuple[str, str]:
+        """Извлекает org_slug и repo_slug из URL (например, https://sourcecraft.dev/Yandex/OSA)"""
+        # Убираем .git если есть
+        clean_url = self.repo_url[:-4] if self.repo_url.endswith('.git') else self.repo_url
+        parts = clean_url.strip("/").split("/")
+        return parts[-2], parts[-1]  # org_slug, repo_slug
+
+    def create_fork(self) -> None:
+        if not self.token:
+            raise ValueError("SourceCraft token is required to create a fork.")
+
+        org_slug, repo_slug = self._extract_slugs()
+        
+        # узнаем свой username чтобы понять куда форкать
+        user_response = requests.get(f"{self.API_BASE}/user", headers=self._get_headers())
+        if user_response.status_code != 200:
+             self._handle_api_error(user_response, "getting SourceCraft user profile", raise_exception=True)
+             
+        current_username = user_response.json().get("username")
+
+        # если мы уже владеем репо - форк не нужен
+        if org_slug == current_username:
+            self.fork_url = self.repo_url
+            logger.info(f"User '{current_username}' already owns the repository. Using original URL.")
+            return
+
+        # Делаем форк
+        url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}/fork"
+        body = {
+            "org_slug": current_username, # Форкаем к себе
+        }
+        
+        response = requests.post(url, headers=self._get_headers(), json=body)
+        
+        if response.status_code in {200, 201, 202}:
+            # Из Swagger: возвращается объект Repository, у которого есть web_url
+            self.fork_url = response.json().get("web_url", f"https://sourcecraft.dev/{current_username}/{repo_slug}")
+            logger.info(f"SourceCraft fork created successfully: {self.fork_url}")
+        else:
+            self._handle_api_error(response, "creating SourceCraft fork", raise_exception=True)
+
+    def star_repository(self) -> None:
+        # В Swagger нет эндпоинта для звезд. 
+        logger.warning("Starring repositories is not supported via SourceCraft public API yet.")
+
+    def create_pull_request(self, title: str = None, body: str = None, changes: bool = False) -> None:
+        if not self.token:
+            raise ValueError("SourceCraft token is required to create a pull request.")
+
+        org_slug, repo_slug = self._extract_slugs()
+        fork_org, _ = self.fork_url.strip("/").split("/")[-2:]
+        
+        # На SourceCraft ветка форка указывается в формате: fork_owner:branch
+        head_branch = f"{fork_org}:{self.branch_name}"
+        
+        url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}/pulls"
+        headers = self._get_headers()
+
+        last_commit = self.repo_head_commit_message() if hasattr(self, 'repo_head_commit_message') else "Auto-generated PR by OSA"
+        pr_title = title if title else last_commit
+        pr_body = (body if body else "") + self.agent_signature
+
+        # Ищем существующие PR
+        params = {"state": "open", "source_branch": head_branch, "target_branch": self.base_branch}
+        list_response = requests.get(url, headers=headers, params=params)
+
+        prs = list_response.json().get("pull_requests",[]) if list_response.status_code == 200 else []
+
+        if prs:
+            existing_pr = prs[0]
+            pr_slug = existing_pr["slug"]
+            logger.info(f"Pull request {pr_slug} already exists.")
+            
+            # Обновление PR
+            update_url = f"{url}/{pr_slug}"
+            update_data = {"description": pr_body}
+            update_res = requests.patch(update_url, headers=headers, json=update_data)
+            
+            if update_res.status_code == 200:
+                logger.info(f"Successfully updated PR {pr_slug}.")
+            else:
+                self._handle_api_error(update_res, f"updating PR {pr_slug}", raise_exception=False)
+                
+        elif changes:
+            # Создание нового PR
+            pr_data = {
+                "title": pr_title,
+                "description": pr_body,
+                "source_branch": head_branch,
+                "target_branch": self.base_branch
+            }
+
+            response = requests.post(url, json=pr_data, headers=headers)
+            if response.status_code == 201:
+                pr_slug = response.json().get("slug", "unknown")
+                logger.info(f"SourceCraft pull request created successfully: {pr_slug}")
+            else:
+                self._handle_api_error(response, "creating pull request", raise_exception=True)
+
+    def _update_about_section(self, repo_path: str, about_content: dict) -> None:
+        parts = repo_path.strip("/").split("/")
+        org_slug, repo_slug = parts[-2], parts[-1]
+        
+        url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}"
+        about_data = {
+            "description": about_content.get("description", "")
+        }
+        
+        response = requests.patch(url, headers=self._get_headers(), json=about_data)
+        if response.status_code in {200, 201}:
+            logger.info(f"Successfully updated SourceCraft repository description for '{repo_path}'.")
+        else:
+            self._handle_api_error(response, f"updating description for '{repo_path}'", raise_exception=False)
+
+    def _build_report_url(self, report_branch: str, report_filename: str) -> str:
+        return f"{self.fork_url}/tree/{report_branch}/{report_filename}"
+
+    def _build_auth_url(self, repo_url: str) -> str:
+        # Для SourceCraft обычно так же, как в GitHub
+        import re
+        match = re.match(r"https?://([^/]+)/(.+)", repo_url)
+        if match:
+            host = match.group(1)
+            path = match.group(2)
+            # Вставляем токен перед хостом
+            return f"https://oauth2:{self.token}@{host}/{path}.git"
+        raise ValueError(f"Unsupported repository URL format for SourceCraft: {repo_url}")
+
+    def validate_topics(self, topics: list[str]) -> list[str]:
+        logger.warning("Topic validation is not yet implemented for SourceCraft.")
         return topics

--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -12,7 +12,7 @@ from osa_tool.core.git.metadata import (
     GitHubMetadataLoader,
     GitLabMetadataLoader,
     GitverseMetadataLoader,
-    SourceCraftMetadataLoader, 
+    SourceCraftMetadataLoader,
     RepositoryMetadata,
 )
 from osa_tool.utils.logger import logger
@@ -459,12 +459,14 @@ class GitAgent(abc.ABC):
             return True
         except GitCommandError as e:
             self._handle_git_error(e, f"pushing to {branch}")
-            logger.error(f"""Push failed: Branch '{branch}' already exists in the fork.
+            logger.error(
+                f"""Push failed: Branch '{branch}' already exists in the fork.
                  To resolve this, please either:
                    1. Choose a different branch name that doesn't exist in the fork 
                       by modifying the `branch_name` parameter.
                    2. Delete the existing branch from forked repository.
-                   3. Delete the fork entirely.""")
+                   3. Delete the fork entirely."""
+            )
             return False
 
     def upload_report(
@@ -1403,13 +1405,14 @@ class GitverseAgent(GitAgent):
 
 
 class SourceCraftAgent(GitAgent):
-    API_BASE = "https://api.sourcecraft.dev" # Или актуальный домен API
+    API_BASE = "https://api.sourcecraft.dev"  # Или актуальный домен API
 
     def _get_token(self) -> str:
         return os.getenv("SOURCECRAFT_TOKEN", os.getenv("GIT_TOKEN", ""))
 
     def _load_metadata(self, repo_url: str) -> RepositoryMetadata:
         from osa_tool.core.git.metadata import SourceCraftMetadataLoader
+
         return SourceCraftMetadataLoader.load_data(repo_url)
 
     def _get_headers(self) -> dict:
@@ -1422,7 +1425,7 @@ class SourceCraftAgent(GitAgent):
 
     def _extract_slugs(self) -> tuple[str, str]:
         """Извлекает org_slug и repo_slug из URL"""
-        clean_url = self.repo_url[:-4] if self.repo_url.endswith('.git') else self.repo_url
+        clean_url = self.repo_url[:-4] if self.repo_url.endswith(".git") else self.repo_url
         parts = clean_url.strip("/").split("/")
         return parts[-2], parts[-1]
 
@@ -1431,14 +1434,14 @@ class SourceCraftAgent(GitAgent):
             raise ValueError("SourceCraft token is required to create a fork.")
 
         org_slug, repo_slug = self._extract_slugs()
-        
+
         # Получаем профиль текущего пользователя
         user_response = requests.get(f"{self.API_BASE}/user", headers=self._get_headers())
         if user_response.status_code != 200:
-             self._handle_api_error(user_response, "getting SourceCraft user profile", raise_exception=True)
+            self._handle_api_error(user_response, "getting SourceCraft user profile", raise_exception=True)
 
         bot_username = user_response.json().get("username", "") if user_response.status_code == 200 else ""
-             
+
         current_username = user_response.json().get("username")
 
         if org_slug == current_username:
@@ -1448,13 +1451,10 @@ class SourceCraftAgent(GitAgent):
 
         # ИСПРАВЛЕНО СОГЛАСНО SWAGGER: Передаем org_slug и default_branch_only
         url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}/fork"
-        body = {
-            "org_slug": current_username,
-            "default_branch_only": True
-        }
-        
+        body = {"org_slug": current_username, "default_branch_only": True}
+
         response = requests.post(url, headers=self._get_headers(), json=body)
-        
+
         if response.status_code in {200, 201, 202}:
             repo_data = response.json()
             self.fork_url = repo_data.get("web_url", f"https://sourcecraft.dev/{current_username}/{repo_slug}")
@@ -1476,7 +1476,9 @@ class SourceCraftAgent(GitAgent):
         url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}/pulls"
         headers = self._get_headers()
 
-        last_commit = self.repo_head_commit_message() if hasattr(self, 'repo_head_commit_message') else "Auto-generated PR by OSA"
+        last_commit = (
+            self.repo_head_commit_message() if hasattr(self, "repo_head_commit_message") else "Auto-generated PR by OSA"
+        )
         pr_title = title if title else last_commit
         pr_body = (body if body else "") + self.agent_signature
 
@@ -1485,25 +1487,25 @@ class SourceCraftAgent(GitAgent):
         if bot_username:
             ql_filter += f' and author_slug="{bot_username}"'
         params = {"filter": ql_filter}
-        
+
         list_response = requests.get(url, headers=headers, params=params)
-        prs = list_response.json().get("pull_requests",[]) if list_response.status_code == 200 else []
+        prs = list_response.json().get("pull_requests", []) if list_response.status_code == 200 else []
 
         if prs:
             existing_pr = prs[0]
             pr_slug = existing_pr.get("slug")
             logger.info(f"Pull request {pr_slug} already exists.")
-            
+
             # Обновление PR
             update_url = f"{url}/{pr_slug}"
             update_data = {"description": pr_body}
             update_res = requests.patch(update_url, headers=headers, json=update_data)
-            
+
             if update_res.status_code == 200:
                 logger.info(f"Successfully updated PR {pr_slug}.")
             else:
                 self._handle_api_error(update_res, f"updating PR {pr_slug}", raise_exception=False)
-                
+
         elif changes:
             # ВАЖНО:
             # Если PR создается из форка, то source_branch в фильтре может нуждаться в указании пространства имен (например, fork_owner:branch), как в GitHub. Swagger об этом умалчивает.
@@ -1513,10 +1515,10 @@ class SourceCraftAgent(GitAgent):
                 "description": pr_body,
                 "source_branch": self.branch_name,
                 "target_branch": self.base_branch,
-                "publish": True  # Чтобы PR не остался в статусе Draft
+                "publish": True,  # Чтобы PR не остался в статусе Draft
             }
-            
-            if hasattr(self, 'fork_id') and self.fork_id:
+
+            if hasattr(self, "fork_id") and self.fork_id:
                 pr_data["fork_repo_id"] = self.fork_id
 
             response = requests.post(url, json=pr_data, headers=headers)
@@ -1529,13 +1531,11 @@ class SourceCraftAgent(GitAgent):
     def _update_about_section(self, repo_path: str, about_content: dict) -> None:
         parts = repo_path.strip("/").split("/")
         org_slug, repo_slug = parts[-2], parts[-1]
-        
+
         # Согласно Swagger, UpdateRepositoryBody принимает description
         url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}"
-        about_data = {
-            "description": about_content.get("description", "")
-        }
-        
+        about_data = {"description": about_content.get("description", "")}
+
         response = requests.patch(url, headers=self._get_headers(), json=about_data)
         if response.status_code in {200, 201}:
             logger.info(f"Successfully updated SourceCraft repository description for '{repo_path}'.")
@@ -1547,6 +1547,7 @@ class SourceCraftAgent(GitAgent):
 
     def _build_auth_url(self, repo_url: str) -> str:
         import re
+
         match = re.match(r"https?://([^/]+)/(.+)", repo_url)
         if match:
             host = match.group(1)

--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -459,14 +459,12 @@ class GitAgent(abc.ABC):
             return True
         except GitCommandError as e:
             self._handle_git_error(e, f"pushing to {branch}")
-            logger.error(
-                f"""Push failed: Branch '{branch}' already exists in the fork.
+            logger.error(f"""Push failed: Branch '{branch}' already exists in the fork.
                  To resolve this, please either:
                    1. Choose a different branch name that doesn't exist in the fork 
                       by modifying the `branch_name` parameter.
                    2. Delete the existing branch from forked repository.
-                   3. Delete the fork entirely."""
-            )
+                   3. Delete the fork entirely.""")
             return False
 
     def upload_report(

--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -1507,7 +1507,18 @@ class SourceCraftAgent(GitAgent):
     def star_repository(self) -> None:
         logger.warning("Starring repositories is not supported via SourceCraft public API yet.")
 
-    def create_pull_request(self, title: str = None, body: str = None, changes: bool = False) -> None:
+    def post_comment(self, pr_slug: str, comment_body: str) -> None:
+        org_slug, repo_slug = self._extract_slugs()
+        url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}/pulls/{pr_slug}/comments"
+        response = requests.post(url, headers=self._get_headers(), json={"body": comment_body})
+        if response.status_code == 201:
+            logger.info(f"Successfully posted a comment to PR {pr_slug}.")
+        else:
+            self._handle_api_error(response, f"posting comment to PR {pr_slug}", raise_exception=False)
+
+    def create_pull_request(
+        self, title: str = None, body: str = None, changes: bool = False, target_branch: str = None
+    ) -> None:
         if not self.token:
             raise ValueError("SourceCraft token is required to create a pull request.")
 
@@ -1516,10 +1527,10 @@ class SourceCraftAgent(GitAgent):
         headers = self._get_headers()
 
         pr_title = title if title else self.repo.head.commit.message.strip()
-        pr_body = (body if body else "") + self.agent_signature
+        base_branch = target_branch or self.base_branch
 
         bot_username = self._get_current_username()
-        ql_filter = f'status=open and source_branch="{self.branch_name}" and target_branch="{self.base_branch}"'
+        ql_filter = f'status=open and source_branch="{self.branch_name}" and target_branch="{base_branch}"'
         if bot_username:
             ql_filter += f' and author_slug="{bot_username}"'
         params = {"filter": ql_filter}
@@ -1532,21 +1543,49 @@ class SourceCraftAgent(GitAgent):
             pr_slug = existing_pr.get("slug")
             logger.info(f"Pull request {pr_slug} already exists.")
 
-            update_url = f"{url}/{pr_slug}"
-            update_data = {"description": pr_body}
-            update_res = requests.patch(update_url, headers=headers, json=update_data)
+            if body and body.strip():
+                self.post_comment(pr_slug, body)
 
-            if update_res.status_code == 200:
-                logger.info(f"Successfully updated PR {pr_slug}.")
-            else:
-                self._handle_api_error(update_res, f"updating PR {pr_slug}", raise_exception=False)
+            if self.pr_report_body.strip():
+                old_description = existing_pr.get("description", "") or ""
+
+                report_pattern = re.compile(r"Generated report - \[.*?\]\(.*?\)")
+                old_reports = report_pattern.findall(old_description)
+                new_reports = report_pattern.findall(self.pr_report_body)
+                all_reports = sorted(list(set(old_reports + new_reports)))
+
+                clean_body = report_pattern.sub("", old_description).replace(self.agent_signature, "").strip()
+
+                updated_body = clean_body
+                if all_reports:
+                    updated_body += "\n\n" + "\n".join(all_reports)
+                updated_body += self.agent_signature
+
+                update_url = f"{url}/{pr_slug}"
+                update_res = requests.patch(update_url, headers=headers, json={"description": updated_body.strip()})
+
+                if update_res.status_code == 200:
+                    logger.info(f"Successfully updated PR {pr_slug} with new reports.")
+                else:
+                    self._handle_api_error(update_res, f"updating PR {pr_slug}", raise_exception=False)
 
         elif changes:
+            report_files = self.get_attachment_branch_files()
+            report_branch = "osa_tool_attachments"
+            for report_file in report_files:
+                report_url = self._build_report_url(report_branch, report_file)
+                report_link = f"\nGenerated report - [{report_file}]({report_url})\n"
+                if report_link not in self.pr_report_body:
+                    self.pr_report_body += report_link
+
+            content = (body if body else "") + self.pr_report_body
+            pr_body = content + self.agent_signature
+
             pr_data = {
                 "title": pr_title,
                 "description": pr_body,
                 "source_branch": self.branch_name,
-                "target_branch": self.base_branch,
+                "target_branch": base_branch,
                 "publish": True,  # prevents draft PR creation
             }
 

--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -1471,7 +1471,7 @@ class SourceCraftAgent(GitAgent):
         return ""
 
     def _extract_slugs(self) -> tuple[str, str]:
-        """Извлекает org_slug и repo_slug из URL"""
+        """Extracts org_slug and repo_slug from the repository URL."""
         clean_url = self.repo_url[:-4] if self.repo_url.endswith(".git") else self.repo_url
         parts = clean_url.strip("/").split("/")
         return parts[-2], parts[-1]
@@ -1491,7 +1491,6 @@ class SourceCraftAgent(GitAgent):
             logger.info(f"User '{current_username}' already owns the repository. Using original URL.")
             return
 
-        # ИСПРАВЛЕНО СОГЛАСНО SWAGGER: Передаем org_slug и default_branch_only
         url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}/fork"
         body = {"org_slug": current_username, "default_branch_only": True}
 
@@ -1500,14 +1499,12 @@ class SourceCraftAgent(GitAgent):
         if response.status_code in {200, 201, 202}:
             repo_data = response.json()
             self.fork_url = repo_data.get("web_url", f"https://sourcecraft.dev/{current_username}/{repo_slug}")
-            # ИСПРАВЛЕНО: Сохраняем ID форка для создания PR
             self.fork_id = repo_data.get("id")
             logger.info(f"SourceCraft fork created successfully: {self.fork_url}")
         else:
             self._handle_api_error(response, "creating SourceCraft fork", raise_exception=True)
 
     def star_repository(self) -> None:
-        # В Swagger действительно нет эндпоинта для постановки звезд.
         logger.warning("Starring repositories is not supported via SourceCraft public API yet.")
 
     def create_pull_request(self, title: str = None, body: str = None, changes: bool = False) -> None:
@@ -1535,7 +1532,6 @@ class SourceCraftAgent(GitAgent):
             pr_slug = existing_pr.get("slug")
             logger.info(f"Pull request {pr_slug} already exists.")
 
-            # Обновление PR
             update_url = f"{url}/{pr_slug}"
             update_data = {"description": pr_body}
             update_res = requests.patch(update_url, headers=headers, json=update_data)
@@ -1546,15 +1542,12 @@ class SourceCraftAgent(GitAgent):
                 self._handle_api_error(update_res, f"updating PR {pr_slug}", raise_exception=False)
 
         elif changes:
-            # ВАЖНО:
-            # Если PR создается из форка, то source_branch в фильтре может нуждаться в указании пространства имен (например, fork_owner:branch), как в GitHub. Swagger об этом умалчивает.
-            # Если при тестировании поиск существующего PR сломается (будет создавать дубликаты), то фильтр нужно будет уточнить (возможно, добавив author_slug).
             pr_data = {
                 "title": pr_title,
                 "description": pr_body,
                 "source_branch": self.branch_name,
                 "target_branch": self.base_branch,
-                "publish": True,  # Чтобы PR не остался в статусе Draft
+                "publish": True,  # prevents draft PR creation
             }
 
             if hasattr(self, "fork_id") and self.fork_id:

--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -1657,6 +1657,26 @@ class SourceCraftAgent(GitAgent):
             logger.warning(f"Failed to check SourceCraft branch: {e}")
             return False
 
+    def get_attachment_branch_files(self, branch: str = "osa_tool_attachments") -> List[str]:
+        try:
+            if not self._check_sourcecraft_branch_exists(branch):
+                return []
+            self.repo.git.fetch("origin", f"{branch}:{branch}_tmp", depth=1)
+            files_output = self.repo.git.ls_tree("-r", "--name-only", f"{branch}_tmp")
+            report_files = [f for f in files_output.split("\n") if f and f.endswith("report.pdf")]
+            self.repo.git.branch("-D", f"{branch}_tmp")
+            logger.debug(f"Found {len(report_files)} report files in branch '{branch}'")
+            return report_files
+        except Exception as e:
+            logger.warning(f"Failed to get files from attachment branch: {e}")
+            return []
+
     def validate_topics(self, topics: list[str]) -> list[str]:
-        logger.warning("Topic validation is not yet implemented for SourceCraft.")
-        return topics
+        valid = []
+        for topic in topics[:20]:
+            normalized = topic.lower().strip()
+            if re.match(r"^[a-z0-9][a-z0-9\-]{0,49}$", normalized):
+                valid.append(normalized)
+            else:
+                logger.debug(f"SourceCraft: skipping invalid topic '{topic}'")
+        return valid

--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -1629,7 +1629,7 @@ class SourceCraftAgent(GitAgent):
             self._handle_api_error(response, f"updating description for '{repo_path}'", raise_exception=False)
 
     def _build_report_url(self, report_branch: str, report_filename: str) -> str:
-        return f"{self.fork_url}/blob/{report_branch}/{report_filename}"
+        return f"{self.fork_url}/browse/{report_filename}?rev={report_branch}"
 
     def _build_auth_url(self, repo_url: str) -> str:
         # SourceCraft git operations go through git.sourcecraft.dev.

--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -235,6 +235,8 @@ class GitAgent(abc.ABC):
             return self._check_gitlab_branch_exists(branch)
         elif "gitverse.ru" in self.repo_url:
             return self._check_gitverse_branch_exists(branch)
+        elif "sourcecraft.dev" in self.repo_url:
+            return self._check_sourcecraft_branch_exists(branch)
 
         logger.warning(f"Cannot check branch existence for platform: {self.repo_url}")
         return False
@@ -1403,7 +1405,7 @@ class GitverseAgent(GitAgent):
 
 
 class SourceCraftAgent(GitAgent):
-    API_BASE = "https://api.sourcecraft.dev"  # Или актуальный домен API
+    API_BASE = "https://api.sourcecraft.tech"
 
     def _get_token(self) -> str:
         return os.getenv("SOURCECRAFT_TOKEN", os.getenv("GIT_TOKEN", ""))
@@ -1414,12 +1416,19 @@ class SourceCraftAgent(GitAgent):
         return SourceCraftMetadataLoader.load_data(repo_url)
 
     def _get_headers(self) -> dict:
-        """Вспомогательный метод для генерации заголовков"""
         return {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",
             "Accept": "application/json",
         }
+
+    def _get_current_username(self) -> str:
+        """Returns the authenticated user's username, or empty string on failure."""
+        response = requests.get(f"{self.API_BASE}/user", headers=self._get_headers())
+        if response.status_code == 200:
+            return response.json().get("username", "")
+        logger.warning(f"Could not fetch SourceCraft user profile: {response.status_code}")
+        return ""
 
     def _extract_slugs(self) -> tuple[str, str]:
         """Извлекает org_slug и repo_slug из URL"""
@@ -1433,14 +1442,9 @@ class SourceCraftAgent(GitAgent):
 
         org_slug, repo_slug = self._extract_slugs()
 
-        # Получаем профиль текущего пользователя
-        user_response = requests.get(f"{self.API_BASE}/user", headers=self._get_headers())
-        if user_response.status_code != 200:
-            self._handle_api_error(user_response, "getting SourceCraft user profile", raise_exception=True)
-
-        bot_username = user_response.json().get("username", "") if user_response.status_code == 200 else ""
-
-        current_username = user_response.json().get("username")
+        current_username = self._get_current_username()
+        if not current_username:
+            raise ValueError("Failed to get SourceCraft user profile.")
 
         if org_slug == current_username:
             self.fork_url = self.repo_url
@@ -1474,13 +1478,10 @@ class SourceCraftAgent(GitAgent):
         url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}/pulls"
         headers = self._get_headers()
 
-        last_commit = (
-            self.repo_head_commit_message() if hasattr(self, "repo_head_commit_message") else "Auto-generated PR by OSA"
-        )
-        pr_title = title if title else last_commit
+        pr_title = title if title else self.repo.head.commit.message.strip()
         pr_body = (body if body else "") + self.agent_signature
 
-        # ИСПРАВЛЕНО СОГЛАСНО SWAGGER: Использование QL фильтра для поиска PR
+        bot_username = self._get_current_username()
         ql_filter = f'status=open and source_branch="{self.branch_name}" and target_branch="{self.base_branch}"'
         if bot_username:
             ql_filter += f' and author_slug="{bot_username}"'
@@ -1526,11 +1527,26 @@ class SourceCraftAgent(GitAgent):
             else:
                 self._handle_api_error(response, "creating pull request", raise_exception=True)
 
+    def update_about_section(self, about_content: dict) -> None:
+        if not self.token:
+            raise ValueError("Git-platform token is required to fill repository's 'About' section.")
+        if not self.fork_url:
+            raise ValueError("Fork URL is not set. Please create a fork first.")
+
+        org_slug, repo_slug = self._extract_slugs()
+        logger.info(f"Updating 'About' section for base repository - {self.repo_url}")
+        self._update_about_section(f"{org_slug}/{repo_slug}", about_content)
+
+        clean_fork = self.fork_url[:-4] if self.fork_url.endswith(".git") else self.fork_url
+        fork_parts = clean_fork.strip("/").split("/")
+        fork_path = f"{fork_parts[-2]}/{fork_parts[-1]}"
+        logger.info(f"Updating 'About' section for the fork - {self.fork_url}")
+        self._update_about_section(fork_path, about_content)
+
     def _update_about_section(self, repo_path: str, about_content: dict) -> None:
         parts = repo_path.strip("/").split("/")
         org_slug, repo_slug = parts[-2], parts[-1]
 
-        # Согласно Swagger, UpdateRepositoryBody принимает description
         url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}"
         about_data = {"description": about_content.get("description", "")}
 
@@ -1541,18 +1557,33 @@ class SourceCraftAgent(GitAgent):
             self._handle_api_error(response, f"updating description for '{repo_path}'", raise_exception=False)
 
     def _build_report_url(self, report_branch: str, report_filename: str) -> str:
-        return f"{self.fork_url}/tree/{report_branch}/{report_filename}"
+        return f"{self.fork_url}/blob/{report_branch}/{report_filename}"
 
     def _build_auth_url(self, repo_url: str) -> str:
-        import re
-
-        match = re.match(r"https?://([^/]+)/(.+)", repo_url)
+        # SourceCraft git operations go through git.sourcecraft.dev.
+        # API returns clone URLs as https://git@git.sourcecraft.dev/org/repo.git,
+        # so we use 'git' as username and the PAT as password.
+        match = re.match(r"https?://(?:git\.)?sourcecraft\.dev/(.+)", repo_url)
         if match:
-            host = match.group(1)
-            path = match.group(2)
-            # Используем токен как username для HTTP basic auth
-            return f"https://{self.token}@{host}/{path}.git"
+            path = match.group(1).rstrip("/").removesuffix(".git")
+            return f"https://git:{self.token}@git.sourcecraft.dev/{path}.git"
         raise ValueError(f"Unsupported repository URL format for SourceCraft: {repo_url}")
+
+    def _check_sourcecraft_branch_exists(self, branch: str) -> bool:
+        """Check if branch exists on SourceCraft using API."""
+        org_slug, repo_slug = self._extract_slugs()
+        url = f"{self.API_BASE}/repos/{org_slug}/{repo_slug}/branches"
+        try:
+            response = requests.get(url, headers=self._get_headers(), timeout=10)
+            if response.status_code == 200:
+                branches = response.json().get("branches", [])
+                return any(b.get("name") == branch for b in branches)
+            else:
+                logger.warning(f"SourceCraft API returned {response.status_code} for branch check")
+                return False
+        except Exception as e:
+            logger.warning(f"Failed to check SourceCraft branch: {e}")
+            return False
 
     def validate_topics(self, topics: list[str]) -> list[str]:
         logger.warning("Topic validation is not yet implemented for SourceCraft.")

--- a/osa_tool/core/git/metadata.py
+++ b/osa_tool/core/git/metadata.py
@@ -370,3 +370,91 @@ class GitverseMetadataLoader(MetadataLoader):
             license_name=license_info.get("name", ""),
             license_url=license_info.get("url", ""),
         )
+
+
+class SourceCraftMetadataLoader(MetadataLoader):
+    API_BASE = "https://api.sourcecraft.dev"
+
+    @classmethod
+    def _load_platform_data(cls, repo_url: str, use_token: bool) -> RepositoryMetadata:
+        """
+        Load SourceCraft repository metadata via SourceCraft API.
+        """
+        # Извлекаем org/repo из URL
+        clean_url = repo_url[:-4] if repo_url.endswith('.git') else repo_url
+        parts = clean_url.strip("/").split("/")
+        org_slug, repo_slug = parts[-2], parts[-1]
+
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+        if use_token:
+            token = os.getenv("SOURCECRAFT_TOKEN", os.getenv("GIT_TOKEN", ""))
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+
+        url = f"{cls.API_BASE}/repos/{org_slug}/{repo_slug}"
+        
+        response = requests.get(url=url, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+        
+        logger.info(f"Successfully fetched SourceCraft metadata for repository: '{org_slug}/{repo_slug}'")
+        return cls._parse_metadata(data)
+
+    @classmethod
+    def _parse_metadata(cls, repo_data: dict) -> RepositoryMetadata:
+        """
+        Parse SourceCraft API response into RepositoryMetadata.
+        """
+        # Маппинг данных из Swagger в наш внутренний формат
+        counters = repo_data.get("counters", {})
+        clone_url = repo_data.get("clone_url", {})
+        org_info = repo_data.get("organization", {})
+        lang_info = repo_data.get("language", {}) or {}
+
+        return RepositoryMetadata(
+            name=repo_data.get("name", ""),
+            full_name=repo_data.get("slug", ""), # В SourceCraft slug обычно и есть full_name
+            owner=org_info.get("slug", ""),
+            owner_url=f"https://sourcecraft.dev/{org_info.get('slug')}" if org_info.get("slug") else None,
+            description=repo_data.get("description", ""),
+            
+            # Статистика
+            stars_count=0,  # В Swagger счетчика звезд нет
+            forks_count=int(counters.get("forks", 0)),
+            watchers_count=0,
+            open_issues_count=int(counters.get("issues", 0)),
+            
+            # Детали
+            default_branch=repo_data.get("default_branch", "master"),
+            created_at="", # В базовом ответе Repository нет даты создания
+            updated_at=repo_data.get("last_updated", ""),
+            pushed_at=repo_data.get("last_updated", ""),
+            size_kb=0, # В Swagger нет поля размера
+            
+            # URLs
+            clone_url_http=clone_url.get("https", ""),
+            clone_url_ssh=clone_url.get("ssh", ""),
+            contributors_url=None,
+            languages_url="", 
+            issues_url=f"https://sourcecraft.dev/{repo_data.get('slug')}/issues",
+            
+            # Языки и темы
+            language=lang_info.get("name", ""),
+            languages=[], 
+            topics=[], # В Swagger для Repository не указаны теги
+            
+            # Настройки
+            has_wiki=False,
+            has_issues=int(counters.get("issues", 0)) > 0,
+            has_projects=False,
+            is_private=repo_data.get("visibility") == "private",
+            homepage_url=repo_data.get("web_url", ""),
+            
+            # Лицензия
+            license_name=None,
+            license_url=None
+        )

--- a/osa_tool/core/git/metadata.py
+++ b/osa_tool/core/git/metadata.py
@@ -381,7 +381,7 @@ class SourceCraftMetadataLoader(MetadataLoader):
         Load SourceCraft repository metadata via SourceCraft API.
         """
         # Извлекаем org/repo из URL
-        clean_url = repo_url[:-4] if repo_url.endswith('.git') else repo_url
+        clean_url = repo_url[:-4] if repo_url.endswith(".git") else repo_url
         parts = clean_url.strip("/").split("/")
         org_slug, repo_slug = parts[-2], parts[-1]
 
@@ -396,11 +396,11 @@ class SourceCraftMetadataLoader(MetadataLoader):
                 headers["Authorization"] = f"Bearer {token}"
 
         url = f"{cls.API_BASE}/repos/{org_slug}/{repo_slug}"
-        
+
         response = requests.get(url=url, headers=headers)
         response.raise_for_status()
         data = response.json()
-        
+
         logger.info(f"Successfully fetched SourceCraft metadata for repository: '{org_slug}/{repo_slug}'")
         return cls._parse_metadata(data)
 
@@ -417,44 +417,38 @@ class SourceCraftMetadataLoader(MetadataLoader):
 
         return RepositoryMetadata(
             name=repo_data.get("name", ""),
-            full_name=repo_data.get("slug", ""), # В SourceCraft slug обычно и есть full_name
+            full_name=repo_data.get("slug", ""),  # В SourceCraft slug обычно и есть full_name
             owner=org_info.get("slug", ""),
             owner_url=f"https://sourcecraft.dev/{org_info.get('slug')}" if org_info.get("slug") else None,
             description=repo_data.get("description", ""),
-            
             # Статистика
             stars_count=0,  # В Swagger счетчика звезд нет
             forks_count=int(counters.get("forks", 0)),
             watchers_count=0,
             open_issues_count=int(counters.get("issues", 0)),
-            
             # Детали
             default_branch=repo_data.get("default_branch", "master"),
-            created_at="", # В базовом ответе Repository нет даты создания
+            created_at="",  # В базовом ответе Repository нет даты создания
             updated_at=repo_data.get("last_updated", ""),
             pushed_at=repo_data.get("last_updated", ""),
-            size_kb=0, # В Swagger нет поля размера
-            
+            size_kb=0,  # В Swagger нет поля размера
             # URLs
             clone_url_http=clone_url.get("https", ""),
             clone_url_ssh=clone_url.get("ssh", ""),
             contributors_url=None,
-            languages_url="", 
+            languages_url="",
             issues_url=f"https://sourcecraft.dev/{repo_data.get('slug')}/issues",
-            
             # Языки и темы
             language=lang_info.get("name", ""),
-            languages=[], 
-            topics=[], # В Swagger для Repository не указаны теги
-            
+            languages=[],
+            topics=[],  # В Swagger для Repository не указаны теги
             # Настройки
             has_wiki=False,
             has_issues=int(counters.get("issues", 0)) > 0,
             has_projects=False,
             is_private=repo_data.get("visibility") == "private",
             homepage_url=repo_data.get("web_url", ""),
-            
             # Лицензия
             license_name=None,
-            license_url=None
+            license_url=None,
         )

--- a/osa_tool/core/git/metadata.py
+++ b/osa_tool/core/git/metadata.py
@@ -620,7 +620,11 @@ class SourceCraftMetadataLoader(MetadataLoader):
             clone_url_ssh=clone_url.get("ssh", ""),
             contributors_url=None,
             languages_url="",
-            issues_url=f"https://sourcecraft.dev/{org_info.get('slug')}/{repo_data.get('slug')}/issues" if org_info.get("slug") and repo_data.get("slug") else "",
+            issues_url=(
+                f"https://sourcecraft.dev/{org_info.get('slug')}/{repo_data.get('slug')}/issues"
+                if org_info.get("slug") and repo_data.get("slug")
+                else ""
+            ),
             language=lang_info.get("name", ""),
             languages=[],
             topics=[],  # not in Repository response

--- a/osa_tool/core/git/metadata.py
+++ b/osa_tool/core/git/metadata.py
@@ -568,7 +568,6 @@ class SourceCraftMetadataLoader(MetadataLoader):
         """
         Load SourceCraft repository metadata via SourceCraft API.
         """
-        # Извлекаем org/repo из URL
         clean_url = repo_url[:-4] if repo_url.endswith(".git") else repo_url
         parts = clean_url.strip("/").split("/")
         org_slug, repo_slug = parts[-2], parts[-1]
@@ -597,7 +596,6 @@ class SourceCraftMetadataLoader(MetadataLoader):
         """
         Parse SourceCraft API response into RepositoryMetadata.
         """
-        # Маппинг данных из Swagger в наш внутренний формат
         counters = repo_data.get("counters", {})
         clone_url = repo_data.get("clone_url", {})
         org_info = repo_data.get("organization", {})
@@ -609,34 +607,28 @@ class SourceCraftMetadataLoader(MetadataLoader):
             owner=org_info.get("slug", ""),
             owner_url=f"https://sourcecraft.dev/{org_info.get('slug')}" if org_info.get("slug") else None,
             description=repo_data.get("description", ""),
-            # Статистика
-            stars_count=0,  # В Swagger счетчика звезд нет
+            stars_count=0,  # not provided by SourceCraft API
             forks_count=int(counters.get("forks", 0)),
             watchers_count=0,
             open_issues_count=int(counters.get("issues", 0)),
-            # Детали
             default_branch=repo_data.get("default_branch", "master"),
-            created_at="",  # В базовом ответе Repository нет даты создания
+            created_at="",  # not in base Repository response
             updated_at=repo_data.get("last_updated", ""),
             pushed_at=repo_data.get("last_updated", ""),
-            size_kb=0,  # В Swagger нет поля размера
-            # URLs
+            size_kb=0,  # not provided by SourceCraft API
             clone_url_http=clone_url.get("https", ""),
             clone_url_ssh=clone_url.get("ssh", ""),
             contributors_url=None,
             languages_url="",
             issues_url=f"https://sourcecraft.dev/{org_info.get('slug')}/{repo_data.get('slug')}/issues",
-            # Языки и темы
             language=lang_info.get("name", ""),
             languages=[],
-            topics=[],  # В Swagger для Repository не указаны теги
-            # Настройки
+            topics=[],  # not in Repository response
             has_wiki=False,
             has_issues=int(counters.get("issues", 0)) > 0,
             has_projects=False,
             is_private=repo_data.get("visibility") == "private",
             homepage_url=repo_data.get("web_url", ""),
-            # Лицензия
             license_name=None,
             license_url=None,
         )

--- a/osa_tool/core/git/metadata.py
+++ b/osa_tool/core/git/metadata.py
@@ -596,9 +596,9 @@ class SourceCraftMetadataLoader(MetadataLoader):
         """
         Parse SourceCraft API response into RepositoryMetadata.
         """
-        counters = repo_data.get("counters", {})
-        clone_url = repo_data.get("clone_url", {})
-        org_info = repo_data.get("organization", {})
+        counters = repo_data.get("counters", {}) or {}
+        clone_url = repo_data.get("clone_url", {}) or {}
+        org_info = repo_data.get("organization", {}) or {}
         lang_info = repo_data.get("language", {}) or {}
 
         return RepositoryMetadata(
@@ -620,7 +620,7 @@ class SourceCraftMetadataLoader(MetadataLoader):
             clone_url_ssh=clone_url.get("ssh", ""),
             contributors_url=None,
             languages_url="",
-            issues_url=f"https://sourcecraft.dev/{org_info.get('slug')}/{repo_data.get('slug')}/issues",
+            issues_url=f"https://sourcecraft.dev/{org_info.get('slug')}/{repo_data.get('slug')}/issues" if org_info.get("slug") and repo_data.get("slug") else "",
             language=lang_info.get("name", ""),
             languages=[],
             topics=[],  # not in Repository response

--- a/osa_tool/core/git/metadata.py
+++ b/osa_tool/core/git/metadata.py
@@ -373,7 +373,7 @@ class GitverseMetadataLoader(MetadataLoader):
 
 
 class SourceCraftMetadataLoader(MetadataLoader):
-    API_BASE = "https://api.sourcecraft.dev"
+    API_BASE = "https://api.sourcecraft.tech"
 
     @classmethod
     def _load_platform_data(cls, repo_url: str, use_token: bool) -> RepositoryMetadata:
@@ -417,7 +417,7 @@ class SourceCraftMetadataLoader(MetadataLoader):
 
         return RepositoryMetadata(
             name=repo_data.get("name", ""),
-            full_name=repo_data.get("slug", ""),  # В SourceCraft slug обычно и есть full_name
+            full_name=f"{org_info.get('slug', '')}/{repo_data.get('slug', '')}",
             owner=org_info.get("slug", ""),
             owner_url=f"https://sourcecraft.dev/{org_info.get('slug')}" if org_info.get("slug") else None,
             description=repo_data.get("description", ""),
@@ -437,7 +437,7 @@ class SourceCraftMetadataLoader(MetadataLoader):
             clone_url_ssh=clone_url.get("ssh", ""),
             contributors_url=None,
             languages_url="",
-            issues_url=f"https://sourcecraft.dev/{repo_data.get('slug')}/issues",
+            issues_url=f"https://sourcecraft.dev/{org_info.get('slug')}/{repo_data.get('slug')}/issues",
             # Языки и темы
             language=lang_info.get("name", ""),
             languages=[],

--- a/osa_tool/docs/templates/ci_config.toml
+++ b/osa_tool/docs/templates/ci_config.toml
@@ -69,4 +69,3 @@ script_template = [
 
 [sourcecraft.sites]
 ref = "release"
-root = "."

--- a/osa_tool/docs/templates/ci_config.toml
+++ b/osa_tool/docs/templates/ci_config.toml
@@ -43,3 +43,30 @@ before_script = ["pip install mkdocs mkdocs-material mkdocstrings[python]"]
 script = ["mkdocs build --config-file osa_mkdocs.yml", "mv site public"]
 artifacts.paths = ["public"]
 rules = [{ if = '$CI_COMMIT_BRANCH == "main"'}]
+
+[sourcecraft.build]
+workflow_name = "build_docs"
+python_version = "3.12"
+script = [
+    "pip install mkdocs mkdocs-material mkdocstrings[python]",
+    "mkdocs build --config-file osa_mkdocs.yml"
+]
+
+[sourcecraft.deploy]
+workflow_name = "deploy_docs"
+python_version = "3.12"
+script_template = [
+    "pip install mkdocs mkdocs-material mkdocstrings[python]",
+    "mkdocs build --config-file osa_mkdocs.yml",
+    "cd site",
+    "git init",
+    "git config user.email 'osa-bot@users.noreply.sourcecraft.dev'",
+    "git config user.name 'OSA Bot'",
+    "git add .",
+    "git commit -m 'Deploy docs'",
+    "git push --force 'https://osa-bot:${{ secrets.SC_TOKEN }}@git.sourcecraft.dev/{full_name}.git' HEAD:release"
+]
+
+[sourcecraft.sites]
+ref = "release"
+root = "."

--- a/osa_tool/docs/templates/community.toml
+++ b/osa_tool/docs/templates/community.toml
@@ -109,7 +109,7 @@ Please check all that apply (`x` inside `[ ]`):
 ## Context
 
 <!--
-  Is this related to any GitHub issue(s)?
+  Is this related to any issue(s)?
 
   You can use keywords to automatically close the related issue.
   For example, (all of) the following will close issue #4567 when your PR is merged.
@@ -409,6 +409,7 @@ security_sourcecraft = """
 Our team take security bugs seriously. We appreciate your efforts to responsibly disclose your
 findings, and will make every effort to acknowledge your contributions.
 
-To report a security issue, please open an issue in the repository at {repo_url}/issues
-and mark it as confidential, or contact the maintainers directly.
+To report a security issue, please open a **private** issue in the repository at {repo_url}/issues —
+set the Visibility to **Private** so only the maintainers can see it. Do not open a public issue,
+as it may expose the vulnerability before a fix is available.
 """

--- a/osa_tool/docs/templates/community.toml
+++ b/osa_tool/docs/templates/community.toml
@@ -399,6 +399,16 @@ release.
 security_gitverse = """
 # Reporting Security Issues
 
-Our team take security bugs seriously. We appreciate your efforts to responsibly disclose your 
+Our team take security bugs seriously. We appreciate your efforts to responsibly disclose your
 findings, and will make every effort to acknowledge your contributions.
+"""
+
+security_sourcecraft = """
+# Reporting Security Issues
+
+Our team take security bugs seriously. We appreciate your efforts to responsibly disclose your
+findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please open an issue in the repository at {repo_url}/issues
+and mark it as confidential, or contact the maintainers directly.
 """

--- a/osa_tool/docs/templates/contributing.toml
+++ b/osa_tool/docs/templates/contributing.toml
@@ -11,12 +11,12 @@ Make sure to familiarize yourself with the project layout before making any majo
 guide = """
 ## How to contribute
 
-1. Fork the [project repository]({url}): click on the 'Fork' button near the top of the page. This creates a copy of the code under your account on the GitHub server.
+1. Fork the [project repository]({url}): click on the 'Fork' button near the top of the page. This creates a copy of the code under your account on the git server.
 
 2. Clone this copy to your local disk:
 
    ```bash
-   git clone git@github.com:YourUsername/{project_name}.git
+   git clone {url}
    ```
 
 3. Create a branch to hold your changes:
@@ -40,7 +40,7 @@ guide = """
    git commit
    ```
 
-   to record your changes in Git, then push them to GitHub with:
+   to record your changes in Git, then push them to the remote repository with:
 
    ```bash
    git push -u origin my-contribution

--- a/osa_tool/docs/templates/contributing.toml
+++ b/osa_tool/docs/templates/contributing.toml
@@ -16,7 +16,7 @@ guide = """
 2. Clone this copy to your local disk:
 
    ```bash
-   git clone {url}
+   git clone {clone_url}
    ```
 
 3. Create a branch to hold your changes:

--- a/osa_tool/operations/analysis/repository_report/report_maker.py
+++ b/osa_tool/operations/analysis/repository_report/report_maker.py
@@ -233,10 +233,16 @@ class AbstractReportGenerator(ABC):
             f"Owner: <a href='{self.metadata.owner_url}' color='#00008B'>{self.metadata.owner}</a>",
             normal_style,
         )
-        created_at = Paragraph(
-            f"Created at: {datetime.strptime(self.metadata.created_at, '%Y-%m-%dT%H:%M:%SZ').strftime('%d.%m.%Y %H:%M')}",
-            normal_style,
-        )
+        if self.metadata.created_at:
+            try:
+                created_at_text = datetime.strptime(self.metadata.created_at, "%Y-%m-%dT%H:%M:%SZ").strftime(
+                    "%d.%m.%Y %H:%M"
+                )
+            except ValueError:
+                created_at_text = self.metadata.created_at
+        else:
+            created_at_text = "N/A"
+        created_at = Paragraph(f"Created at: {created_at_text}", normal_style)
 
         bullet_list = ListFlowable(
             [

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -1140,14 +1140,12 @@ class DocGen(object):
                 else:
                     docstring = component["details"]["docstring"] if component["details"]["docstring"] else ""
 
-                prompt_structure.append(
-                    f"""
+                prompt_structure.append(f"""
                     {_type.capitalize()} name: {component["name"] if _type == "class" else component["details"]["method_name"]}
                     Component description: {docstring}
                     Component place in hierarchy: {file}
                     Component importance score: {score}
-                    """
-                )
+                    """)
 
         logger.info(f"Generating the main idea of the project...")
 

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -1140,12 +1140,14 @@ class DocGen(object):
                 else:
                     docstring = component["details"]["docstring"] if component["details"]["docstring"] else ""
 
-                prompt_structure.append(f"""
+                prompt_structure.append(
+                    f"""
                     {_type.capitalize()} name: {component["name"] if _type == "class" else component["details"]["method_name"]}
                     Component description: {docstring}
                     Component place in hierarchy: {file}
                     Component importance score: {score}
-                    """)
+                    """
+                )
 
         logger.info(f"Generating the main idea of the project...")
 

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -1441,33 +1441,43 @@ class DocGen(object):
 
             if build_wf not in workflows_section:
                 workflows_section[build_wf] = {
-                    "tasks": [{
-                        "name": build_wf,
-                        "cubes": [{
-                            "name": "mkdocs-build",
-                            "image": f"docker.io/library/python:{sc_cfg['build']['python_version']}",
-                            "script": sc_cfg["build"]["script"],
-                        }],
-                    }]
+                    "tasks": [
+                        {
+                            "name": build_wf,
+                            "cubes": [
+                                {
+                                    "name": "mkdocs-build",
+                                    "image": f"docker.io/library/python:{sc_cfg['build']['python_version']}",
+                                    "script": sc_cfg["build"]["script"],
+                                }
+                            ],
+                        }
+                    ]
                 }
 
             if deploy_wf not in workflows_section:
                 deploy_script = [s.replace("{full_name}", full_name) for s in sc_cfg["deploy"]["script_template"]]
                 workflows_section[deploy_wf] = {
-                    "tasks": [{
-                        "name": deploy_wf,
-                        "cubes": [{
-                            "name": "mkdocs-deploy",
-                            "image": f"docker.io/library/python:{sc_cfg['deploy']['python_version']}",
-                            "script": deploy_script,
-                        }],
-                    }]
+                    "tasks": [
+                        {
+                            "name": deploy_wf,
+                            "cubes": [
+                                {
+                                    "name": "mkdocs-deploy",
+                                    "image": f"docker.io/library/python:{sc_cfg['deploy']['python_version']}",
+                                    "script": deploy_script,
+                                }
+                            ],
+                        }
+                    ]
                 }
 
             sc_data["workflows"] = workflows_section
 
             yaml.Dumper.ignore_aliases = lambda *args: True
-            sc_ci_file.write_text(yaml.safe_dump(sc_data, default_flow_style=False, sort_keys=False, allow_unicode=True))
+            sc_ci_file.write_text(
+                yaml.safe_dump(sc_data, default_flow_style=False, sort_keys=False, allow_unicode=True)
+            )
 
             sites_cfg = sc_cfg.get("sites", {})
             sites_file = sc_ci_dir / "sites.yaml"

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -1407,6 +1407,85 @@ class DocGen(object):
                 f"GitLab CI created: {gitlab_file}.\nThe resulting OSA documentation can be downloaded and reviewed at the 'mkdocs_build' job's artifacts initated by MR.\nIt will be automatically deployed once MR is proceeded into the main branch.\nNote that artifacts of the 'mkdocs_build' job are set to expire in a span of 1 week."
             )
 
+        if "sourcecraft" in git_host:
+            sc_cfg = cfg.get("sourcecraft", {})
+            full_name = self.config_manager.get_git_settings().full_name
+
+            sc_ci_dir = Path(path).resolve() / ".sourcecraft"
+            sc_ci_dir.mkdir(parents=True, exist_ok=True)
+            sc_ci_file = sc_ci_dir / "ci.yaml"
+
+            sc_data = yaml.safe_load(sc_ci_file.read_text()) or {} if sc_ci_file.exists() else {}
+
+            build_wf = sc_cfg["build"]["workflow_name"]
+            deploy_wf = sc_cfg["deploy"]["workflow_name"]
+
+            on_section = sc_data.get("on", {})
+
+            pr_list = on_section.get("pull_request", [])
+            if pr_list:
+                existing = pr_list[0].setdefault("workflows", [])
+                if build_wf not in existing:
+                    existing.append(build_wf)
+            else:
+                pr_list.append({"workflows": [build_wf]})
+            on_section["pull_request"] = pr_list
+
+            push_list = on_section.get("push", [])
+            if not any(deploy_wf in entry.get("workflows", []) for entry in push_list):
+                push_list.append({"workflows": [deploy_wf], "filter": {"branches": ["main", "master"]}})
+            on_section["push"] = push_list
+            sc_data["on"] = on_section
+
+            workflows_section = sc_data.get("workflows", {})
+
+            if build_wf not in workflows_section:
+                workflows_section[build_wf] = {
+                    "tasks": [{
+                        "name": build_wf,
+                        "cubes": [{
+                            "name": "mkdocs-build",
+                            "image": f"docker.io/library/python:{sc_cfg['build']['python_version']}",
+                            "script": sc_cfg["build"]["script"],
+                        }],
+                    }]
+                }
+
+            if deploy_wf not in workflows_section:
+                deploy_script = [s.replace("{full_name}", full_name) for s in sc_cfg["deploy"]["script_template"]]
+                workflows_section[deploy_wf] = {
+                    "tasks": [{
+                        "name": deploy_wf,
+                        "cubes": [{
+                            "name": "mkdocs-deploy",
+                            "image": f"docker.io/library/python:{sc_cfg['deploy']['python_version']}",
+                            "script": deploy_script,
+                        }],
+                    }]
+                }
+
+            sc_data["workflows"] = workflows_section
+
+            yaml.Dumper.ignore_aliases = lambda *args: True
+            sc_ci_file.write_text(yaml.safe_dump(sc_data, default_flow_style=False, sort_keys=False, allow_unicode=True))
+
+            sites_cfg = sc_cfg.get("sites", {})
+            sites_file = sc_ci_dir / "sites.yaml"
+            sites_data = {"site": {"root": sites_cfg.get("root", "."), "ref": sites_cfg.get("ref", "release")}}
+            sites_file.write_text(yaml.safe_dump(sites_data, default_flow_style=False, sort_keys=False))
+
+            full_name = self.config_manager.get_git_settings().full_name
+            org_slug = full_name.split("/")[0]
+            repo_name = self.config_manager.get_git_settings().name
+            logger.info(
+                f"SourceCraft CI updated: {sc_ci_file}\n"
+                f"SourceCraft Sites config created: {sites_file}\n"
+                "To enable automatic documentation deployment:\n"
+                "1. Create a SourceCraft personal access token with repository write access.\n"
+                "2. Add it as a CI secret named 'SC_TOKEN' in your repository settings.\n"
+                f"3. The documentation will be served at https://{org_slug}.sourcecraft.site/{repo_name}"
+            )
+
     @staticmethod
     def _sanitize_name(name: str) -> str:
         """

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -1481,7 +1481,7 @@ class DocGen(object):
 
             sites_cfg = sc_cfg.get("sites", {})
             sites_file = sc_ci_dir / "sites.yaml"
-            sites_data = {"site": {"root": sites_cfg.get("root", "."), "ref": sites_cfg.get("ref", "release")}}
+            sites_data = {"site": {"ref": sites_cfg.get("ref", "release")}}
             sites_file.write_text(yaml.safe_dump(sites_data, default_flow_style=False, sort_keys=False))
 
             full_name = self.config_manager.get_git_settings().full_name

--- a/osa_tool/operations/codebase/workflow_generation/workflow_generator.py
+++ b/osa_tool/operations/codebase/workflow_generation/workflow_generator.py
@@ -588,11 +588,11 @@ class SourceCraftWorkflowGenerator(WorkflowGenerator):
     ) -> dict:
         return self._cube("black", python_version, [f"pip install black", f"black {options} {src}"])
 
-    def generate_unit_test(self, python_version: str = "3.11", test_command: str = "pytest tests/") -> dict:
+    def generate_unit_test(self, python_version: str = "3.11", test_command: str = "pytest") -> dict:
         return self._cube(
-            f"pytest-{python_version}",
+            f"pytest-{python_version.replace('.', '-')}",
             python_version,
-            ["pip install -r requirements.txt pytest pytest-cov", test_command],
+            ["pip install -r requirements.txt pytest pytest-cov", f"{test_command} || test $? -eq 5"],
         )
 
     def generate_pep8(self, tool: str = "flake8", python_version: str = "3.11", src: str = ".") -> dict:

--- a/osa_tool/operations/codebase/workflow_generation/workflow_generator.py
+++ b/osa_tool/operations/codebase/workflow_generation/workflow_generator.py
@@ -560,6 +560,148 @@ class GitHubWorkflowGenerator(WorkflowGenerator):
         return generated_files
 
 
+class SourceCraftWorkflowGenerator(WorkflowGenerator):
+    """
+    Generates .sourcecraft/ci.yaml using SourceCraft's native CI format.
+
+    SourceCraft CI structure: on → workflows → tasks → cubes.
+    All workflows run concurrently; all cubes within a task run on the same VM.
+    Reference: https://sourcecraft.dev/portal/docs/en/sourcecraft/ci-cd-ref/
+    """
+
+    def load_template(self, template_name: str) -> str:
+        template_path = os.path.join(
+            osa_project_root(), "config", "templates", "workflow", "sourcecraft", template_name
+        )
+        with open(template_path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def _cube(self, name: str, python_version: str, script: List[str]) -> dict:
+        return {
+            "name": name,
+            "image": f"docker.io/library/python:{python_version}",
+            "script": script,
+        }
+
+    def generate_black_formatter(self, python_version: str = "3.11", src: str = ".", options: str = "--check --diff") -> dict:
+        return self._cube("black", python_version, [f"pip install black", f"black {options} {src}"])
+
+    def generate_unit_test(self, python_version: str = "3.11", test_command: str = "pytest tests/") -> dict:
+        return self._cube(
+            f"pytest-{python_version}",
+            python_version,
+            ["pip install -r requirements.txt pytest pytest-cov", test_command],
+        )
+
+    def generate_pep8(self, tool: str = "flake8", python_version: str = "3.11", src: str = ".") -> dict:
+        return self._cube(tool, python_version, [f"pip install {tool}", f"{tool} {src}"])
+
+    def generate_autopep8(self, python_version: str = "3.11", src: str = ".") -> dict:
+        return self._cube("autopep8", python_version, ["pip install autopep8", f"autopep8 --check --recursive {src}"])
+
+    def generate_fix_pep8_command(self, python_version: str = "3.11", src: str = ".") -> dict:
+        return self._cube("fix-pep8", python_version, ["pip install autopep8", f"autopep8 --in-place --recursive {src}"])
+
+    def generate_slash_command_dispatch(self) -> None:
+        pass
+
+    def generate_pypi_publish(self, python_version: str = "3.11", use_poetry: bool = False) -> dict:
+        if use_poetry:
+            script = [
+                "pip install poetry",
+                "poetry build",
+                "poetry publish --username __token__ --password ${{ secrets.PYPI_TOKEN }}",
+            ]
+        else:
+            script = [
+                "pip install build twine",
+                "python -m build",
+                "twine upload dist/* -u __token__ -p ${{ secrets.PYPI_TOKEN }}",
+            ]
+        return self._cube("pypi-publish", python_version, script)
+
+    def generate_selected_jobs(self, settings: WorkflowSettings, plan: Plan) -> List[str]:
+        self._ensure_output_dir()
+
+        python_versions: List[str] = settings.python_versions or ["3.11"]
+        latest = python_versions[-1]
+        branches: List[str] = settings.branches or []
+
+        lint_cubes = []
+        test_cubes = []
+        publish_cubes = []
+
+        if settings.include_black:
+            lint_cubes.append(self.generate_black_formatter(python_version=latest))
+            if plan is not None:
+                plan.mark_done("include_black")
+
+        if settings.include_pep8:
+            lint_cubes.append(self.generate_pep8(tool=settings.pep8_tool, python_version=latest))
+            if plan is not None:
+                plan.mark_done("include_pep8")
+
+        if settings.include_autopep8:
+            lint_cubes.append(self.generate_autopep8(python_version=latest))
+            if plan is not None:
+                plan.mark_done("include_autopep8")
+
+        if settings.include_fix_pep8:
+            lint_cubes.append(self.generate_fix_pep8_command(python_version=latest))
+            if plan is not None:
+                plan.mark_done("include_fix_pep8")
+
+        if settings.include_tests:
+            for version in python_versions:
+                test_cubes.append(self.generate_unit_test(python_version=version))
+            if plan is not None:
+                plan.mark_done("include_tests")
+
+        if settings.include_pypi:
+            publish_cubes.append(self.generate_pypi_publish(python_version=latest, use_poetry=settings.use_poetry))
+            if plan is not None:
+                plan.mark_done("include_pypi")
+
+        if not any([lint_cubes, test_cubes, publish_cubes]):
+            return []
+
+        # Build on: section
+        ci_workflows = []
+        if lint_cubes:
+            ci_workflows.append("lint")
+        if test_cubes:
+            ci_workflows.append("tests")
+
+        on_section = {}
+        if ci_workflows:
+            push_entry: dict = {"workflows": list(ci_workflows)}
+            if branches:
+                push_entry["filter"] = {"branches": branches}
+            on_section["push"] = [push_entry]
+            on_section["pull_request"] = [{"workflows": list(ci_workflows)}]
+
+        if publish_cubes:
+            on_section.setdefault("push", [])
+            on_section["push"].append({"workflows": ["publish"], "filter": {"tags": ["*.*.*"]}})
+
+        # Build workflows: section
+        workflows_section = {}
+        if lint_cubes:
+            workflows_section["lint"] = {"tasks": [{"name": "lint", "cubes": lint_cubes}]}
+        if test_cubes:
+            workflows_section["tests"] = {"tasks": [{"name": "tests", "cubes": test_cubes}]}
+        if publish_cubes:
+            workflows_section["publish"] = {"tasks": [{"name": "publish", "cubes": publish_cubes}]}
+
+        config = {"on": on_section, "workflows": workflows_section}
+
+        file_path = os.path.join(self.output_dir, "ci.yaml")
+        with open(file_path, "w", encoding="utf-8") as f:
+            yaml.dump(config, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+        return [file_path]
+
+
 class GitLabWorkflowGenerator(WorkflowGenerator):
     def load_template(self, template_name: str) -> str:
         """

--- a/osa_tool/operations/codebase/workflow_generation/workflow_generator.py
+++ b/osa_tool/operations/codebase/workflow_generation/workflow_generator.py
@@ -669,7 +669,6 @@ class SourceCraftWorkflowGenerator(WorkflowGenerator):
         if not any([lint_cubes, test_cubes, publish_cubes]):
             return []
 
-        # Build on: section
         ci_workflows = []
         if lint_cubes:
             ci_workflows.append("lint")
@@ -688,7 +687,6 @@ class SourceCraftWorkflowGenerator(WorkflowGenerator):
             on_section.setdefault("push", [])
             on_section["push"].append({"workflows": ["publish"], "filter": {"tags": ["*.*.*"]}})
 
-        # Build workflows: section
         workflows_section = {}
         if lint_cubes:
             workflows_section["lint"] = {"tasks": [{"name": "lint", "cubes": lint_cubes}]}

--- a/osa_tool/operations/codebase/workflow_generation/workflow_generator.py
+++ b/osa_tool/operations/codebase/workflow_generation/workflow_generator.py
@@ -583,7 +583,9 @@ class SourceCraftWorkflowGenerator(WorkflowGenerator):
             "script": script,
         }
 
-    def generate_black_formatter(self, python_version: str = "3.11", src: str = ".", options: str = "--check --diff") -> dict:
+    def generate_black_formatter(
+        self, python_version: str = "3.11", src: str = ".", options: str = "--check --diff"
+    ) -> dict:
         return self._cube("black", python_version, [f"pip install black", f"black {options} {src}"])
 
     def generate_unit_test(self, python_version: str = "3.11", test_command: str = "pytest tests/") -> dict:
@@ -600,7 +602,9 @@ class SourceCraftWorkflowGenerator(WorkflowGenerator):
         return self._cube("autopep8", python_version, ["pip install autopep8", f"autopep8 --check --recursive {src}"])
 
     def generate_fix_pep8_command(self, python_version: str = "3.11", src: str = ".") -> dict:
-        return self._cube("fix-pep8", python_version, ["pip install autopep8", f"autopep8 --in-place --recursive {src}"])
+        return self._cube(
+            "fix-pep8", python_version, ["pip install autopep8", f"autopep8 --in-place --recursive {src}"]
+        )
 
     def generate_slash_command_dispatch(self) -> None:
         pass

--- a/osa_tool/operations/codebase/workflow_generation/workflow_generator.py
+++ b/osa_tool/operations/codebase/workflow_generation/workflow_generator.py
@@ -695,11 +695,47 @@ class SourceCraftWorkflowGenerator(WorkflowGenerator):
         if publish_cubes:
             workflows_section["publish"] = {"tasks": [{"name": "publish", "cubes": publish_cubes}]}
 
-        config = {"on": on_section, "workflows": workflows_section}
-
         file_path = os.path.join(self.output_dir, "ci.yaml")
+
+        # Merge with existing ci.yaml to avoid overwriting e.g. build_docs/deploy_docs
+        if os.path.isfile(file_path):
+            try:
+                with open(file_path, encoding="utf-8") as f:
+                    existing = yaml.safe_load(f) or {}
+            except (yaml.YAMLError, IOError, OSError):
+                existing = {}
+        else:
+            existing = {}
+
+        # Merge on_section into existing
+        existing_on = existing.get("on", {})
+        for trigger, new_entries in on_section.items():
+            existing_entries = existing_on.get(trigger, [])
+            for new_entry in new_entries:
+                new_wfs = set(new_entry.get("workflows", []))
+                # Append workflows to first matching entry or add a new entry
+                merged = False
+                for ex_entry in existing_entries:
+                    ex_wfs = set(ex_entry.get("workflows", []))
+                    # Same filter context → merge workflow lists
+                    if ex_entry.get("filter") == new_entry.get("filter"):
+                        ex_entry["workflows"] = list(ex_wfs | new_wfs)
+                        merged = True
+                        break
+                if not merged:
+                    existing_entries.append(new_entry)
+            existing_on[trigger] = existing_entries
+        existing["on"] = existing_on
+
+        # Merge workflows_section into existing (don't overwrite existing keys)
+        existing_workflows = existing.get("workflows", {})
+        for name, definition in workflows_section.items():
+            if name not in existing_workflows:
+                existing_workflows[name] = definition
+        existing["workflows"] = existing_workflows
+
         with open(file_path, "w", encoding="utf-8") as f:
-            yaml.dump(config, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+            yaml.dump(existing, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
         return [file_path]
 

--- a/osa_tool/operations/docs/community_docs_generation/community.py
+++ b/osa_tool/operations/docs/community_docs_generation/community.py
@@ -55,6 +55,14 @@ class CommunityTemplateBuilder:
             self.docs_issue_to_save = os.path.join(self.repo_path, "DOCUMENTATION_ISSUE.md")
             self.feature_issue_to_save = os.path.join(self.issue_templates_path, "FEATURE_ISSUE.md")
             self.bug_issue_to_save = os.path.join(self.issue_templates_path, "BUG_ISSUE.md")
+        elif "sourcecraft" in self.config_manager.get_git_settings().host:
+            repo_root = os.path.join(os.getcwd(), parse_folder_name(self.repo_url))
+            self.code_of_conduct_to_save = os.path.join(repo_root, "CODE_OF_CONDUCT.md")
+            self.security_to_save = os.path.join(repo_root, "SECURITY.md")
+            self.pr_to_save = os.path.join(repo_root, "PULL_REQUEST_TEMPLATE.md")
+            self.docs_issue_to_save = os.path.join(repo_root, "DOCUMENTATION_ISSUE.md")
+            self.feature_issue_to_save = os.path.join(repo_root, "FEATURE_ISSUE.md")
+            self.bug_issue_to_save = os.path.join(repo_root, "BUG_ISSUE.md")
 
     def load_template(self) -> dict:
         """

--- a/osa_tool/operations/docs/community_docs_generation/contributing.py
+++ b/osa_tool/operations/docs/community_docs_generation/contributing.py
@@ -59,7 +59,11 @@ class ContributingBuilder:
     @property
     def guide(self) -> str:
         """Generates the guide section with basic project contribution instructions."""
-        return self._template["guide"].format(url=self.url_path, project_name=self.metadata.name)
+        return self._template["guide"].format(
+            url=self.url_path,
+            project_name=self.metadata.name,
+            clone_url=self.metadata.clone_url_http or self.url_path,
+        )
 
     @property
     def before_pr(self) -> str:

--- a/osa_tool/operations/docs/community_docs_generation/contributing.py
+++ b/osa_tool/operations/docs/community_docs_generation/contributing.py
@@ -37,6 +37,10 @@ class ContributingBuilder:
         )
         self.file_to_save = os.path.join(self.repo_path, "CONTRIBUTING.md")
 
+        if "sourcecraft" in self.config_manager.get_git_settings().host:
+            repo_root = os.path.join(os.getcwd(), parse_folder_name(self.repo_url))
+            self.file_to_save = os.path.join(repo_root, "CONTRIBUTING.md")
+
     def load_template(self) -> dict:
         """
         Loads a TOML template file and returns its sections as a dictionary.

--- a/osa_tool/operations/docs/readme_generation/pipeline/nodes/context_collector.py
+++ b/osa_tool/operations/docs/readme_generation/pipeline/nodes/context_collector.py
@@ -266,6 +266,7 @@ def _run_llm_analyses(context: ReadmeContext, raw_ctx: dict) -> dict:
             repository_tree=raw_ctx["repo_tree"],
             key_files_content=raw_ctx["key_files_content"],
             existing_readme=raw_ctx["existing_readme"],
+            clone_url_http=context.metadata.clone_url_http or "",
         ),
         parser=LlmTextOutput,
         system_message=build_system_message(context, "repo_analysis"),

--- a/osa_tool/operations/docs/readme_generation/pipeline/nodes/deterministic_builder.py
+++ b/osa_tool/operations/docs/readme_generation/pipeline/nodes/deterministic_builder.py
@@ -1,6 +1,7 @@
 """Deterministic README sections (header, installation, license, etc.) — logic reused by section_generator."""
 
 import os
+from datetime import datetime
 from typing import Any
 
 import requests
@@ -160,9 +161,10 @@ class _DeterministicSections:
             return content
 
         git = self._cm.get_git_settings()
+        year = self._meta.created_at.split("-")[0] if self._meta.created_at else str(datetime.now().year)
         content = self._tpl["citation"] + self._tpl["citation_v2"].format(
             owner=self._meta.owner,
-            year=self._meta.created_at.split("-")[0],
+            year=year,
             repo_name=git.name,
             publisher=git.host_domain,
             repository_url=git.repository,

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -4,7 +4,7 @@ import time
 from typing import Any, Callable
 
 from osa_tool.config.settings import ConfigManager
-from osa_tool.core.git.git_agent import GitHubAgent, GitLabAgent, GitverseAgent, GitAgent
+from osa_tool.core.git.git_agent import GitHubAgent, GitLabAgent, GitverseAgent, SourceCraftAgent, GitAgent
 from osa_tool.operations.analysis.repository_report.report_maker import ReportGenerator, WhatHasBeenDoneReportGenerator
 from osa_tool.operations.analysis.repository_validation.doc_validator import DocValidator
 from osa_tool.operations.analysis.repository_validation.paper_validator import PaperValidator
@@ -28,6 +28,7 @@ from osa_tool.scheduler.workflow_manager import (
     GitHubWorkflowManager,
     GitLabWorkflowManager,
     GitverseWorkflowManager,
+    SourceCraftWorkflowManager,
     WorkflowManager,
 )
 from osa_tool.utils.arguments_parser import build_parser_from_yaml
@@ -257,6 +258,9 @@ def initialize_git_platform(args) -> tuple[GitAgent, WorkflowManager]:
     elif "gitverse.ru" in args.repository:
         git_agent = GitverseAgent(args.repository, args.branch, author=args.author)
         workflow_manager = GitverseWorkflowManager(args.repository, git_agent.metadata, args)
+    elif "sourcecraft.dev" in args.repository:
+        git_agent = SourceCraftAgent(args.repository, args.branch, author=args.author)
+        workflow_manager = SourceCraftWorkflowManager(args.repository, git_agent.metadata, args)
     else:
         raise ValueError(f"Cannot initialize Git Agent and Workflow Manager for this platform: {args.repository}")
 

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -5,11 +5,11 @@ from typing import Any, Callable
 
 from osa_tool.config.settings import ConfigManager
 from osa_tool.core.git.git_agent import (
-    GitHubAgent, 
-    GitLabAgent, 
-    GitverseAgent, 
-    SourceCraftAgent, 
-    GitAgent, 
+    GitHubAgent,
+    GitLabAgent,
+    GitverseAgent,
+    SourceCraftAgent,
+    GitAgent,
     LocalGitAgent
 )
 from osa_tool.operations.analysis.repository_report.report_maker import ReportGenerator, WhatHasBeenDoneReportGenerator

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -10,7 +10,7 @@ from osa_tool.core.git.git_agent import (
     GitverseAgent,
     SourceCraftAgent,
     GitAgent,
-    LocalGitAgent
+    LocalGitAgent,
 )
 from osa_tool.operations.analysis.repository_report.report_maker import ReportGenerator, WhatHasBeenDoneReportGenerator
 from osa_tool.operations.analysis.repository_validation.doc_validator import DocValidator

--- a/osa_tool/run.py
+++ b/osa_tool/run.py
@@ -4,7 +4,14 @@ import time
 from typing import Any, Callable
 
 from osa_tool.config.settings import ConfigManager
-from osa_tool.core.git.git_agent import GitHubAgent, GitLabAgent, GitverseAgent, SourceCraftAgent, GitAgent, LocalGitAgent
+from osa_tool.core.git.git_agent import (
+    GitHubAgent, 
+    GitLabAgent, 
+    GitverseAgent, 
+    SourceCraftAgent, 
+    GitAgent, 
+    LocalGitAgent
+)
 from osa_tool.operations.analysis.repository_report.report_maker import ReportGenerator, WhatHasBeenDoneReportGenerator
 from osa_tool.operations.analysis.repository_validation.doc_validator import DocValidator
 from osa_tool.operations.analysis.repository_validation.paper_validator import PaperValidator

--- a/osa_tool/scheduler/workflow_manager.py
+++ b/osa_tool/scheduler/workflow_manager.py
@@ -361,7 +361,7 @@ class GitverseWorkflowManager(WorkflowManager):
 class SourceCraftWorkflowManager(WorkflowManager):
     """
     Workflow manager implementation for SourceCraft platform.
-    
+
     Uses `.sourcecraft/ci.yaml` file (or similar) for workflows storage.
     Note: Currently acts as a stub until specific SourceCraft workflow generators are implemented.
     """
@@ -391,7 +391,7 @@ class SourceCraftWorkflowManager(WorkflowManager):
         # Предполагаем структуру, похожую на GitHub/GitLab
         if "jobs" in content:
             return set(content["jobs"].keys())
-        
+
         # Если структура плоская
         special_keys = {"image", "variables", "stages", "before_script", "after_script"}
         jobs = {k for k in content.keys() if k not in special_keys and isinstance(content[k], dict)}
@@ -410,7 +410,7 @@ class SourceCraftWorkflowManager(WorkflowManager):
         """
         logger.warning("SourceCraft workflow generation is currently in stub mode.")
         workflow_file = os.path.join(output_dir, "ci.yaml")
-        
+
         stub_workflow = """# Auto-generated SourceCraft CI/CD pipeline
 name: OSA CI
 on: [push, pull_request]

--- a/osa_tool/scheduler/workflow_manager.py
+++ b/osa_tool/scheduler/workflow_manager.py
@@ -356,3 +356,74 @@ class GitverseWorkflowManager(WorkflowManager):
     def _generate_files(self, workflow_settings, output_dir) -> list[str]:
         generator = GitHubWorkflowGenerator(output_dir)
         return generator.generate_selected_jobs(workflow_settings, self.plan)
+
+
+class SourceCraftWorkflowManager(WorkflowManager):
+    """
+    Workflow manager implementation for SourceCraft platform.
+    
+    Uses `.sourcecraft/ci.yaml` file (or similar) for workflows storage.
+    Note: Currently acts as a stub until specific SourceCraft workflow generators are implemented.
+    """
+
+    def _locate_workflow_path(self) -> str | None:
+        # Предполагаем, что CI хранится в .sourcecraft/ci.yaml
+        wdir = os.path.join(self.base_path, ".sourcecraft")
+        fpath = os.path.join(wdir, "ci.yaml")
+        if os.path.isfile(fpath):
+            return fpath
+        return None
+
+    def _find_existing_jobs(self) -> set[str]:
+        if not self.workflow_path:
+            return set()
+
+        try:
+            with open(self.workflow_path, encoding="utf-8") as f:
+                content = yaml.safe_load(f)
+        except (yaml.YAMLError, IOError, OSError) as e:
+            logger.warning(f"Failed to load {self.workflow_path}: {e}")
+            return set()
+
+        if not content:
+            return set()
+
+        # Предполагаем структуру, похожую на GitHub/GitLab
+        if "jobs" in content:
+            return set(content["jobs"].keys())
+        
+        # Если структура плоская
+        special_keys = {"image", "variables", "stages", "before_script", "after_script"}
+        jobs = {k for k in content.keys() if k not in special_keys and isinstance(content[k], dict)}
+        return jobs
+
+    def _get_output_dir(self) -> str:
+        out_dir = os.path.join(self.base_path, ".sourcecraft")
+        os.makedirs(out_dir, exist_ok=True)
+        return out_dir
+
+    def _generate_files(self, workflow_settings, output_dir) -> list[str]:
+        """
+        Stub for generating SourceCraft workflows.
+        Since we don't have a dedicated SourceCraftWorkflowGenerator yet,
+        we just create a dummy file to simulate the process.
+        """
+        logger.warning("SourceCraft workflow generation is currently in stub mode.")
+        workflow_file = os.path.join(output_dir, "ci.yaml")
+        
+        stub_workflow = """# Auto-generated SourceCraft CI/CD pipeline
+name: OSA CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "OSA SourceCraft workflow generated successfully!"
+"""
+        try:
+            with open(workflow_file, "w", encoding="utf-8") as f:
+                f.write(stub_workflow)
+            return [workflow_file]
+        except Exception as e:
+            logger.error(f"Failed to write SourceCraft workflow: {e}")
+            return

--- a/osa_tool/scheduler/workflow_manager.py
+++ b/osa_tool/scheduler/workflow_manager.py
@@ -34,12 +34,12 @@ class WorkflowManager(ABC):
 
     job_name_for_key = {
         "include_black": ["black", "lint", "Lint", "format"],
-        "include_tests": ["test", "unit_tests"],
+        "include_tests": ["test", "unit_tests", "tests"],
         "include_pep8": ["lint", "Lint", "pep8_check"],
         "include_autopep8": ["autopep8"],
         "include_fix_pep8": ["fix_pep8_command", "fix-pep8"],
         "slash-command-dispatch": ["slash_command_dispatch", "slashCommandDispatch"],
-        "pypi-publish": ["pypi_publish", "pypi-publish"],
+        "pypi-publish": ["pypi_publish", "pypi-publish", "publish"],
     }
 
     def __init__(self, repo_url: str, metadata: RepositoryMetadata, args: Any):
@@ -387,12 +387,11 @@ class SourceCraftWorkflowManager(WorkflowManager):
         if not content:
             return set()
 
-        if "jobs" in content:
-            return set(content["jobs"].keys())
+        workflows = content.get("workflows")
+        if isinstance(workflows, dict):
+            return set(workflows.keys())
 
-        special_keys = {"image", "variables", "stages", "before_script", "after_script"}
-        jobs = {k for k in content.keys() if k not in special_keys and isinstance(content[k], dict)}
-        return jobs
+        return set()
 
     def _get_output_dir(self) -> str:
         out_dir = os.path.join(self.base_path, ".sourcecraft")

--- a/osa_tool/scheduler/workflow_manager.py
+++ b/osa_tool/scheduler/workflow_manager.py
@@ -10,6 +10,7 @@ from osa_tool.core.git.metadata import RepositoryMetadata
 from osa_tool.operations.codebase.workflow_generation.workflow_generator import (
     GitHubWorkflowGenerator,
     GitLabWorkflowGenerator,
+    SourceCraftWorkflowGenerator,
 )
 from osa_tool.scheduler.plan import Plan
 from osa_tool.tools.repository_analysis.sourcerank import SourceRank
@@ -403,27 +404,5 @@ class SourceCraftWorkflowManager(WorkflowManager):
         return out_dir
 
     def _generate_files(self, workflow_settings, output_dir) -> list[str]:
-        """
-        Stub for generating SourceCraft workflows.
-        Since we don't have a dedicated SourceCraftWorkflowGenerator yet,
-        we just create a dummy file to simulate the process.
-        """
-        logger.warning("SourceCraft workflow generation is currently in stub mode.")
-        workflow_file = os.path.join(output_dir, "ci.yaml")
-
-        stub_workflow = """# Auto-generated SourceCraft CI/CD pipeline
-name: OSA CI
-on: [push, pull_request]
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "OSA SourceCraft workflow generated successfully!"
-"""
-        try:
-            with open(workflow_file, "w", encoding="utf-8") as f:
-                f.write(stub_workflow)
-            return [workflow_file]
-        except Exception as e:
-            logger.error(f"Failed to write SourceCraft workflow: {e}")
-            return
+        generator = SourceCraftWorkflowGenerator(output_dir)
+        return generator.generate_selected_jobs(workflow_settings, self.plan)

--- a/osa_tool/scheduler/workflow_manager.py
+++ b/osa_tool/scheduler/workflow_manager.py
@@ -363,12 +363,10 @@ class SourceCraftWorkflowManager(WorkflowManager):
     """
     Workflow manager implementation for SourceCraft platform.
 
-    Uses `.sourcecraft/ci.yaml` file (or similar) for workflows storage.
-    Note: Currently acts as a stub until specific SourceCraft workflow generators are implemented.
+    Uses `.sourcecraft/ci.yaml` file for workflows storage.
     """
 
     def _locate_workflow_path(self) -> str | None:
-        # Предполагаем, что CI хранится в .sourcecraft/ci.yaml
         wdir = os.path.join(self.base_path, ".sourcecraft")
         fpath = os.path.join(wdir, "ci.yaml")
         if os.path.isfile(fpath):
@@ -389,11 +387,9 @@ class SourceCraftWorkflowManager(WorkflowManager):
         if not content:
             return set()
 
-        # Предполагаем структуру, похожую на GitHub/GitLab
         if "jobs" in content:
             return set(content["jobs"].keys())
 
-        # Если структура плоская
         special_keys = {"image", "variables", "stages", "before_script", "after_script"}
         jobs = {k for k in content.keys() if k not in special_keys and isinstance(content[k], dict)}
         return jobs

--- a/osa_tool/utils/utils.py
+++ b/osa_tool/utils/utils.py
@@ -33,7 +33,12 @@ def parse_folder_name(repo_url: str) -> str:
     Returns:
         The name of the folder where the repository will be cloned.
     """
-    patterns = [r"github\.com/[^/]+/([^/]+)", r"gitlab[^/]+/[^/]+/([^/]+)", r"gitverse\.ru/[^/]+/([^/]+)"]
+    patterns = [
+        r"github\.com/[^/]+/([^/]+)",
+        r"gitlab[^/]+/[^/]+/([^/]+)",
+        r"gitverse\.ru/[^/]+/([^/]+)",
+        r"sourcecraft\.dev/[^/]+/([^/]+)",
+    ]
     for pattern in patterns:
         match = re.search(pattern, repo_url)
         if match:

--- a/tests/data_factory.py
+++ b/tests/data_factory.py
@@ -24,7 +24,8 @@ class DataFactory:
         """Generating data for GitSettings (GitHub only)"""
         repo_name = random_word()
         user_name = random_word()
-        platform_domain = f"{platform}.com" if platform != "gitverse" else f"{platform}.ru"
+        domains = {"gitverse": "gitverse.ru", "sourcecraft": "sourcecraft.dev"}
+        platform_domain = domains.get(platform, f"{platform}.com")
 
         return {
             "repository": f"https://{platform_domain}/{user_name}/{repo_name}",
@@ -117,6 +118,28 @@ class DataFactory:
     def generate_repository_metadata_raw(platform: str, owner: str, repo_name: str, repo_url: str) -> dict:
         now = datetime.now(timezone.utc)
         random_date = lambda offset=0: (now - timedelta(days=random.randint(offset, offset + 1000)))
+        format_date_z = lambda dt: dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        if platform == "sourcecraft":
+            return {
+                "name": repo_name,
+                "slug": repo_name,
+                "description": " ".join([random_word() for _ in range(random.randint(5, 15))]),
+                "default_branch": random.choice(["main", "master"]),
+                "last_updated": format_date_z(random_date(10)),
+                "visibility": random.choice(["public", "private"]),
+                "web_url": f"https://sourcecraft.dev/{owner}/{repo_name}",
+                "counters": {
+                    "forks": str(random.randint(0, 100)),
+                    "issues": str(random.randint(0, 50)),
+                },
+                "clone_url": {
+                    "https": f"https://git@git.sourcecraft.dev/{owner}/{repo_name}.git",
+                    "ssh": f"git@git.sourcecraft.dev:{owner}/{repo_name}.git",
+                },
+                "organization": {"slug": owner},
+                "language": random.choice([None, {}, {"name": "Python", "color": "#3572A5"}]),
+            }
 
         if platform == "gitlab":
             format_date = lambda dt: dt.strftime("%Y-%m-%dT%H:%M:%S")
@@ -129,9 +152,12 @@ class DataFactory:
             updated_at = format_date(random_date(100))
             pushed_at = format_date(random_date(10))
 
-        base_domain = {"github": "github.com", "gitlab": "gitlab.com", "gitverse": "gitverse.ru"}.get(
-            platform, "github.com"
-        )
+        base_domain = {
+            "github": "github.com",
+            "gitlab": "gitlab.com",
+            "gitverse": "gitverse.ru",
+            "sourcecraft": "sourcecraft.dev",
+        }.get(platform, "github.com")
 
         metadata = {
             "name": repo_name,
@@ -182,6 +208,43 @@ class DataFactory:
         self, platform: str, owner: str, repo_name: str, repo_url: str
     ) -> RepositoryMetadata:
         raw = self.generate_repository_metadata_raw(platform, owner, repo_name, repo_url)
+
+        if platform == "sourcecraft":
+            org_info = raw.get("organization", {})
+            lang_info = raw.get("language", {}) or {}
+            counters = raw.get("counters", {})
+            clone_url = raw.get("clone_url", {})
+            return RepositoryMetadata(
+                name=raw["name"],
+                full_name=f"{org_info.get('slug', '')}/{raw.get('slug', '')}",
+                owner=org_info.get("slug", ""),
+                owner_url=f"https://sourcecraft.dev/{org_info.get('slug')}" if org_info.get("slug") else None,
+                description=raw.get("description", ""),
+                stars_count=0,
+                forks_count=int(counters.get("forks", 0)),
+                watchers_count=0,
+                open_issues_count=int(counters.get("issues", 0)),
+                default_branch=raw.get("default_branch", "master"),
+                created_at="",
+                updated_at=raw.get("last_updated", ""),
+                pushed_at=raw.get("last_updated", ""),
+                size_kb=0,
+                clone_url_http=clone_url.get("https", ""),
+                clone_url_ssh=clone_url.get("ssh", ""),
+                contributors_url=None,
+                languages_url="",
+                issues_url=f"https://sourcecraft.dev/{org_info.get('slug')}/{raw.get('slug')}/issues",
+                language=lang_info.get("name", ""),
+                languages=[],
+                topics=[],
+                has_wiki=False,
+                has_issues=int(counters.get("issues", 0)) > 0,
+                has_projects=False,
+                is_private=raw.get("visibility") == "private",
+                homepage_url=raw.get("web_url", ""),
+                license_name=None,
+                license_url=None,
+            )
 
         return RepositoryMetadata(
             name=raw["name"],

--- a/tests/data_factory.py
+++ b/tests/data_factory.py
@@ -233,7 +233,11 @@ class DataFactory:
                 clone_url_ssh=clone_url.get("ssh", ""),
                 contributors_url=None,
                 languages_url="",
-                issues_url=f"https://sourcecraft.dev/{org_info.get('slug')}/{raw.get('slug')}/issues",
+                issues_url=(
+                    f"https://sourcecraft.dev/{org_info.get('slug')}/{raw.get('slug')}/issues"
+                    if org_info.get("slug") and raw.get("slug")
+                    else ""
+                ),
                 language=lang_info.get("name", ""),
                 languages=[],
                 topics=[],

--- a/tests/unit/core/git/test_git_agent.py
+++ b/tests/unit/core/git/test_git_agent.py
@@ -441,7 +441,6 @@ def test_gitverse_agent_star_repository_already_starred(
             mock_put.assert_not_called()
 
 
-<<<<<<< HEAD
 # ---------------------------------------------------------------------------
 # SourceCraft Agent
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/git/test_git_agent.py
+++ b/tests/unit/core/git/test_git_agent.py
@@ -440,11 +440,6 @@ def test_gitverse_agent_star_repository_already_starred(
             mock_put.assert_not_called()
 
 
-# ---------------------------------------------------------------------------
-# SourceCraft Agent
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture
 def sourcecraft_agent_instance(temp_clone_dir, mock_repository_metadata, repo_info, monkeypatch):
     platform, owner, repo_name, repo_url = repo_info
@@ -552,21 +547,54 @@ def test_sourcecraft_agent_create_pull_request_new(
     with patch.dict(os.environ, {"SOURCECRAFT_TOKEN": "any_token"}):
         with patch("requests.get", side_effect=[mock_user_response, mock_list_response]):
             with patch("requests.post", return_value=mock_create_response) as mock_post:
-                sourcecraft_agent_instance.create_pull_request(changes=True)
+                with patch.object(sourcecraft_agent_instance, "get_attachment_branch_files", return_value=[]):
+                    sourcecraft_agent_instance.create_pull_request(changes=True)
 
-                # Assert
-                mock_post.assert_called_once()
-                _, kwargs = mock_post.call_args
-                assert kwargs["json"]["source_branch"] == "osa_tool"
-                assert kwargs["json"]["target_branch"] == "main"
-                assert kwargs["json"]["publish"] is True
+                    # Assert
+                    mock_post.assert_called_once()
+                    _, kwargs = mock_post.call_args
+                    assert kwargs["json"]["source_branch"] == "osa_tool"
+                    assert kwargs["json"]["target_branch"] == "main"
+                    assert kwargs["json"]["publish"] is True
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_agent_create_pull_request_new_with_reports(
+    sourcecraft_agent_instance, mock_repo, mock_requests_response_factory, repo_info
+):
+    # Arrange — new PR, attachment branch has one PDF — link must appear in PR description
+    platform, owner, repo_name, repo_url = repo_info
+    sourcecraft_agent_instance.repo = mock_repo
+    sourcecraft_agent_instance.fork_url = repo_url
+    mock_repo.head.commit.message = "Test commit"
+    sourcecraft_agent_instance.base_branch = "main"
+    sourcecraft_agent_instance.branch_name = "osa_tool"
+
+    mock_user_response = mock_requests_response_factory(status_code=200, json_data={"username": "bot_user"})
+    mock_list_response = mock_requests_response_factory(status_code=200, json_data={"pull_requests": []})
+    mock_create_response = mock_requests_response_factory(status_code=201, json_data={"slug": "pr-2"})
+
+    # Act
+    with patch.dict(os.environ, {"SOURCECRAFT_TOKEN": "any_token"}):
+        with patch("requests.get", side_effect=[mock_user_response, mock_list_response]):
+            with patch("requests.post", return_value=mock_create_response) as mock_post:
+                with patch.object(
+                    sourcecraft_agent_instance, "get_attachment_branch_files", return_value=["report.pdf"]
+                ):
+                    sourcecraft_agent_instance.create_pull_request(changes=True)
+
+                    # Assert — report link included in PR description
+                    mock_post.assert_called_once()
+                    _, kwargs = mock_post.call_args
+                    assert "Generated report" in kwargs["json"]["description"]
+                    assert "report.pdf" in kwargs["json"]["description"]
 
 
 @pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
 def test_sourcecraft_agent_create_pull_request_dedup(
     sourcecraft_agent_instance, mock_repo, mock_requests_response_factory, repo_info
 ):
-    # Arrange — existing PR found, must PATCH instead of POST
+    # Arrange — existing PR found, no new reports → must not POST a new PR
     platform, owner, repo_name, repo_url = repo_info
     sourcecraft_agent_instance.repo = mock_repo
     mock_repo.head.commit.message = "Test commit"
@@ -575,7 +603,38 @@ def test_sourcecraft_agent_create_pull_request_dedup(
 
     mock_user_response = mock_requests_response_factory(status_code=200, json_data={"username": "bot_user"})
     mock_list_response = mock_requests_response_factory(
-        status_code=200, json_data={"pull_requests": [{"slug": "pr-42"}]}
+        status_code=200, json_data={"pull_requests": [{"slug": "pr-42", "description": ""}]}
+    )
+
+    # Act
+    with patch.dict(os.environ, {"SOURCECRAFT_TOKEN": "any_token"}):
+        with patch("requests.get", side_effect=[mock_user_response, mock_list_response]):
+            with patch("requests.post") as mock_post:
+                with patch("requests.patch") as mock_patch:
+                    sourcecraft_agent_instance.create_pull_request(changes=True)
+
+                    # Assert — no new PR created, no unnecessary PATCH
+                    mock_post.assert_not_called()
+                    mock_patch.assert_not_called()
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_agent_create_pull_request_update_reports(
+    sourcecraft_agent_instance, mock_repo, mock_requests_response_factory, repo_info
+):
+    # Arrange — existing PR with old report, new report in pr_report_body → PATCH with merged reports
+    platform, owner, repo_name, repo_url = repo_info
+    sourcecraft_agent_instance.repo = mock_repo
+    mock_repo.head.commit.message = "Test commit"
+    sourcecraft_agent_instance.base_branch = "main"
+    sourcecraft_agent_instance.branch_name = "osa_tool"
+    sourcecraft_agent_instance.pr_report_body = "\nGenerated report - [report_new.pdf](https://example.com/new)\n"
+
+    old_description = "Previous description\n\nGenerated report - [report_old.pdf](https://example.com/old)"
+    mock_user_response = mock_requests_response_factory(status_code=200, json_data={"username": "bot_user"})
+    mock_list_response = mock_requests_response_factory(
+        status_code=200,
+        json_data={"pull_requests": [{"slug": "pr-42", "description": old_description}]},
     )
     mock_update_response = mock_requests_response_factory(status_code=200, json_data={"slug": "pr-42"})
 
@@ -586,9 +645,12 @@ def test_sourcecraft_agent_create_pull_request_dedup(
                 with patch("requests.patch", return_value=mock_update_response) as mock_patch:
                     sourcecraft_agent_instance.create_pull_request(changes=True)
 
-                    # Assert
+                    # Assert — no new PR, description updated with both report links
                     mock_post.assert_not_called()
                     mock_patch.assert_called_once()
+                    patched_description = mock_patch.call_args.kwargs["json"]["description"]
+                    assert "report_old.pdf" in patched_description
+                    assert "report_new.pdf" in patched_description
 
 
 @pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)

--- a/tests/unit/core/git/test_git_agent.py
+++ b/tests/unit/core/git/test_git_agent.py
@@ -701,7 +701,8 @@ def test_sourcecraft_agent_build_report_url(sourcecraft_agent_instance, repo_inf
     assert "?rev=" in report_url
     assert "attachments" in report_url
     assert "report.pdf" in report_url
-    
+
+
 
 @patch("osa_tool.core.git.git_agent.Repo")
 @patch("osa_tool.core.git.metadata.Repo")

--- a/tests/unit/core/git/test_git_agent.py
+++ b/tests/unit/core/git/test_git_agent.py
@@ -703,7 +703,6 @@ def test_sourcecraft_agent_build_report_url(sourcecraft_agent_instance, repo_inf
     assert "report.pdf" in report_url
 
 
-
 @patch("osa_tool.core.git.git_agent.Repo")
 @patch("osa_tool.core.git.metadata.Repo")
 @patch.object(LocalGitAgent, "_clone_chosen_branch")

--- a/tests/unit/core/git/test_git_agent.py
+++ b/tests/unit/core/git/test_git_agent.py
@@ -104,7 +104,6 @@ def test_git_agent_clone_repository_failure_git_error(git_agent_base_setup):
 
     # Act
     with patch("git.Repo.clone_from", side_effect=git_error):
-        # Match changed: now we catch the message from _handle_git_error
         with pytest.raises(Exception, match=r"Git operation 'cloning repository.*' failed"):
             agent.clone_repository()
 

--- a/tests/unit/core/git/test_git_agent.py
+++ b/tests/unit/core/git/test_git_agent.py
@@ -697,10 +697,11 @@ def test_sourcecraft_agent_build_report_url(sourcecraft_agent_instance, repo_inf
     report_url = sourcecraft_agent_instance._build_report_url("attachments", "report.pdf")
 
     # Assert
-    assert "/blob/" in report_url
+    assert "/browse/" in report_url
+    assert "?rev=" in report_url
     assert "attachments" in report_url
     assert "report.pdf" in report_url
-
+    
 
 @patch("osa_tool.core.git.git_agent.Repo")
 @patch("osa_tool.core.git.metadata.Repo")

--- a/tests/unit/core/git/test_git_agent.py
+++ b/tests/unit/core/git/test_git_agent.py
@@ -5,11 +5,12 @@ from unittest.mock import Mock, patch, ANY
 import pytest
 from git import Repo, GitCommandError
 
-from osa_tool.core.git.git_agent import GitHubAgent, GitverseAgent, GitLabAgent
+from osa_tool.core.git.git_agent import GitHubAgent, GitverseAgent, GitLabAgent, SourceCraftAgent
 from osa_tool.core.git.metadata import (
     GitHubMetadataLoader,
     GitverseMetadataLoader,
     GitLabMetadataLoader,
+    SourceCraftMetadataLoader,
 )
 from osa_tool.utils.utils import parse_folder_name
 
@@ -438,3 +439,207 @@ def test_gitverse_agent_star_repository_already_starred(
             # Assert
             mock_get.assert_called_once()
             mock_put.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# SourceCraft Agent
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sourcecraft_agent_instance(temp_clone_dir, mock_repository_metadata, repo_info, monkeypatch):
+    platform, owner, repo_name, repo_url = repo_info
+    monkeypatch.setenv("SOURCECRAFT_TOKEN", "fixture-token-sourcecraft")
+    with patch.object(SourceCraftMetadataLoader, "load_data", return_value=mock_repository_metadata):
+        agent = SourceCraftAgent(repo_url)
+        agent.clone_dir = os.path.join(temp_clone_dir, parse_folder_name(repo_url))
+        yield agent
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_agent_create_fork_success(
+    sourcecraft_agent_instance, mock_requests_response_factory, repo_info
+):
+    # Arrange
+    platform, owner, repo_name, repo_url = repo_info
+    expected_api_url = f"https://api.sourcecraft.tech/repos/{owner}/{repo_name}/fork"
+    expected_fork_url = f"https://sourcecraft.dev/other_user/{repo_name}"
+
+    mock_user_response = mock_requests_response_factory(status_code=200, json_data={"username": "other_user"})
+    mock_fork_response = mock_requests_response_factory(
+        status_code=201, json_data={"web_url": expected_fork_url, "id": 42}
+    )
+
+    # Act
+    with patch.dict(os.environ, {"SOURCECRAFT_TOKEN": "any_token"}):
+        with (
+            patch("requests.get", return_value=mock_user_response),
+            patch("requests.post", return_value=mock_fork_response) as mock_post,
+        ):
+            sourcecraft_agent_instance.create_fork()
+
+            # Assert
+            mock_post.assert_called_once()
+            args, kwargs = mock_post.call_args
+            assert expected_api_url in args[0]
+            assert kwargs["headers"]["Authorization"].startswith("Bearer")
+            assert sourcecraft_agent_instance.fork_url == expected_fork_url
+            assert sourcecraft_agent_instance.fork_id == 42
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_agent_create_fork_self_owned(
+    sourcecraft_agent_instance, mock_requests_response_factory, repo_info
+):
+    # Arrange — user is already the owner, no fork should be created
+    platform, owner, repo_name, repo_url = repo_info
+    mock_user_response = mock_requests_response_factory(status_code=200, json_data={"username": owner})
+
+    # Act
+    with patch.dict(os.environ, {"SOURCECRAFT_TOKEN": "any_token"}):
+        with (
+            patch("requests.get", return_value=mock_user_response),
+            patch("requests.post") as mock_post,
+        ):
+            sourcecraft_agent_instance.create_fork()
+
+            # Assert
+            mock_post.assert_not_called()
+            assert sourcecraft_agent_instance.fork_url == repo_url
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_agent_create_fork_failure(sourcecraft_agent_instance, mock_requests_response_factory):
+    # Arrange
+    mock_user_response = mock_requests_response_factory(status_code=200, json_data={"username": "other_user"})
+    mock_fork_response = mock_requests_response_factory(status_code=401, text_data="Unauthorized")
+
+    # Act & Assert
+    with patch.dict(os.environ, {"SOURCECRAFT_TOKEN": "any_token"}):
+        with (
+            patch("requests.get", return_value=mock_user_response),
+            patch("requests.post", return_value=mock_fork_response),
+        ):
+            with pytest.raises(ValueError, match=r"API operation 'creating SourceCraft fork' failed"):
+                sourcecraft_agent_instance.create_fork()
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_agent_star_repository_noop(sourcecraft_agent_instance):
+    # SourceCraft has no starring API — must not call any HTTP endpoint
+    with patch("requests.put") as mock_put, patch("requests.get") as mock_get:
+        sourcecraft_agent_instance.star_repository()
+
+        # Assert
+        mock_put.assert_not_called()
+        mock_get.assert_not_called()
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_agent_create_pull_request_new(
+    sourcecraft_agent_instance, mock_repo, mock_requests_response_factory, repo_info
+):
+    # Arrange
+    platform, owner, repo_name, repo_url = repo_info
+    sourcecraft_agent_instance.repo = mock_repo
+    sourcecraft_agent_instance.fork_url = repo_url
+    mock_repo.head.commit.message = "Test commit"
+    sourcecraft_agent_instance.base_branch = "main"
+    sourcecraft_agent_instance.branch_name = "osa_tool"
+
+    mock_user_response = mock_requests_response_factory(status_code=200, json_data={"username": "bot_user"})
+    mock_list_response = mock_requests_response_factory(status_code=200, json_data={"pull_requests": []})
+    mock_create_response = mock_requests_response_factory(status_code=201, json_data={"slug": "pr-1"})
+
+    # Act
+    with patch.dict(os.environ, {"SOURCECRAFT_TOKEN": "any_token"}):
+        with patch("requests.get", side_effect=[mock_user_response, mock_list_response]):
+            with patch("requests.post", return_value=mock_create_response) as mock_post:
+                sourcecraft_agent_instance.create_pull_request(changes=True)
+
+                # Assert
+                mock_post.assert_called_once()
+                _, kwargs = mock_post.call_args
+                assert kwargs["json"]["source_branch"] == "osa_tool"
+                assert kwargs["json"]["target_branch"] == "main"
+                assert kwargs["json"]["publish"] is True
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_agent_create_pull_request_dedup(
+    sourcecraft_agent_instance, mock_repo, mock_requests_response_factory, repo_info
+):
+    # Arrange — existing PR found, must PATCH instead of POST
+    platform, owner, repo_name, repo_url = repo_info
+    sourcecraft_agent_instance.repo = mock_repo
+    mock_repo.head.commit.message = "Test commit"
+    sourcecraft_agent_instance.base_branch = "main"
+    sourcecraft_agent_instance.branch_name = "osa_tool"
+
+    mock_user_response = mock_requests_response_factory(status_code=200, json_data={"username": "bot_user"})
+    mock_list_response = mock_requests_response_factory(
+        status_code=200, json_data={"pull_requests": [{"slug": "pr-42"}]}
+    )
+    mock_update_response = mock_requests_response_factory(status_code=200, json_data={"slug": "pr-42"})
+
+    # Act
+    with patch.dict(os.environ, {"SOURCECRAFT_TOKEN": "any_token"}):
+        with patch("requests.get", side_effect=[mock_user_response, mock_list_response]):
+            with patch("requests.post") as mock_post:
+                with patch("requests.patch", return_value=mock_update_response) as mock_patch:
+                    sourcecraft_agent_instance.create_pull_request(changes=True)
+
+                    # Assert
+                    mock_post.assert_not_called()
+                    mock_patch.assert_called_once()
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_agent_update_about_section(
+    sourcecraft_agent_instance, mock_requests_response_factory, repo_info
+):
+    # Arrange
+    platform, owner, repo_name, repo_url = repo_info
+    sourcecraft_agent_instance.fork_url = repo_url
+    mock_response = mock_requests_response_factory(status_code=200, json_data={})
+
+    # Act
+    with patch.dict(os.environ, {"SOURCECRAFT_TOKEN": "any_token"}):
+        with patch("requests.patch", return_value=mock_response) as mock_patch:
+            sourcecraft_agent_instance.update_about_section({"description": "Test description"})
+
+            # Assert — called twice: once for base repo, once for fork
+            assert mock_patch.call_count == 2
+            for call in mock_patch.call_args_list:
+                _, kwargs = call
+                assert kwargs["json"]["description"] == "Test description"
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_agent_build_auth_url(sourcecraft_agent_instance, repo_info):
+    # Arrange
+    platform, owner, repo_name, repo_url = repo_info
+
+    # Act
+    auth_url = sourcecraft_agent_instance._build_auth_url(repo_url)
+
+    # Assert
+    assert auth_url.startswith("https://git:")
+    assert "git.sourcecraft.dev" in auth_url
+    assert auth_url.endswith(".git")
+    assert "fixture-token-sourcecraft" in auth_url
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_agent_build_report_url(sourcecraft_agent_instance, repo_info):
+    # Arrange
+    platform, owner, repo_name, repo_url = repo_info
+    sourcecraft_agent_instance.fork_url = repo_url
+
+    # Act
+    report_url = sourcecraft_agent_instance._build_report_url("attachments", "report.pdf")
+
+    # Assert
+    assert "/blob/" in report_url
+    assert "attachments" in report_url
+    assert "report.pdf" in report_url

--- a/tests/unit/core/git/test_git_agent.py
+++ b/tests/unit/core/git/test_git_agent.py
@@ -457,9 +457,7 @@ def sourcecraft_agent_instance(temp_clone_dir, mock_repository_metadata, repo_in
 
 
 @pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
-def test_sourcecraft_agent_create_fork_success(
-    sourcecraft_agent_instance, mock_requests_response_factory, repo_info
-):
+def test_sourcecraft_agent_create_fork_success(sourcecraft_agent_instance, mock_requests_response_factory, repo_info):
     # Arrange
     platform, owner, repo_name, repo_url = repo_info
     expected_api_url = f"https://api.sourcecraft.tech/repos/{owner}/{repo_name}/fork"
@@ -595,9 +593,7 @@ def test_sourcecraft_agent_create_pull_request_dedup(
 
 
 @pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
-def test_sourcecraft_agent_update_about_section(
-    sourcecraft_agent_instance, mock_requests_response_factory, repo_info
-):
+def test_sourcecraft_agent_update_about_section(sourcecraft_agent_instance, mock_requests_response_factory, repo_info):
     # Arrange
     platform, owner, repo_name, repo_url = repo_info
     sourcecraft_agent_instance.fork_url = repo_url

--- a/tests/unit/core/git/test_git_agent.py
+++ b/tests/unit/core/git/test_git_agent.py
@@ -483,7 +483,7 @@ def test_sourcecraft_agent_create_fork_success(sourcecraft_agent_instance, mock_
 def test_sourcecraft_agent_create_fork_self_owned(
     sourcecraft_agent_instance, mock_requests_response_factory, repo_info
 ):
-    # Arrange — user is already the owner, no fork should be created
+    # Arrange - user is already the owner, no fork should be created
     platform, owner, repo_name, repo_url = repo_info
     mock_user_response = mock_requests_response_factory(status_code=200, json_data={"username": owner})
 
@@ -518,7 +518,7 @@ def test_sourcecraft_agent_create_fork_failure(sourcecraft_agent_instance, mock_
 
 @pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
 def test_sourcecraft_agent_star_repository_noop(sourcecraft_agent_instance):
-    # SourceCraft has no starring API — must not call any HTTP endpoint
+    # SourceCraft has no starring API - must not call any HTTP endpoint
     with patch("requests.put") as mock_put, patch("requests.get") as mock_get:
         sourcecraft_agent_instance.star_repository()
 
@@ -562,7 +562,7 @@ def test_sourcecraft_agent_create_pull_request_new(
 def test_sourcecraft_agent_create_pull_request_new_with_reports(
     sourcecraft_agent_instance, mock_repo, mock_requests_response_factory, repo_info
 ):
-    # Arrange — new PR, attachment branch has one PDF — link must appear in PR description
+    # Arrange - new PR, attachment branch has one PDF - link must appear in PR description
     platform, owner, repo_name, repo_url = repo_info
     sourcecraft_agent_instance.repo = mock_repo
     sourcecraft_agent_instance.fork_url = repo_url
@@ -594,7 +594,7 @@ def test_sourcecraft_agent_create_pull_request_new_with_reports(
 def test_sourcecraft_agent_create_pull_request_dedup(
     sourcecraft_agent_instance, mock_repo, mock_requests_response_factory, repo_info
 ):
-    # Arrange — existing PR found, no new reports → must not POST a new PR
+    # Arrange - existing PR found, no new reports - must not POST a new PR
     platform, owner, repo_name, repo_url = repo_info
     sourcecraft_agent_instance.repo = mock_repo
     mock_repo.head.commit.message = "Test commit"
@@ -613,7 +613,7 @@ def test_sourcecraft_agent_create_pull_request_dedup(
                 with patch("requests.patch") as mock_patch:
                     sourcecraft_agent_instance.create_pull_request(changes=True)
 
-                    # Assert — no new PR created, no unnecessary PATCH
+                    # Assert - no new PR created, no unnecessary PATCH
                     mock_post.assert_not_called()
                     mock_patch.assert_not_called()
 
@@ -622,7 +622,7 @@ def test_sourcecraft_agent_create_pull_request_dedup(
 def test_sourcecraft_agent_create_pull_request_update_reports(
     sourcecraft_agent_instance, mock_repo, mock_requests_response_factory, repo_info
 ):
-    # Arrange — existing PR with old report, new report in pr_report_body → PATCH with merged reports
+    # Arrange - existing PR with old report, new report in pr_report_body - PATCH with merged reports
     platform, owner, repo_name, repo_url = repo_info
     sourcecraft_agent_instance.repo = mock_repo
     mock_repo.head.commit.message = "Test commit"
@@ -645,7 +645,7 @@ def test_sourcecraft_agent_create_pull_request_update_reports(
                 with patch("requests.patch", return_value=mock_update_response) as mock_patch:
                     sourcecraft_agent_instance.create_pull_request(changes=True)
 
-                    # Assert — no new PR, description updated with both report links
+                    # Assert - no new PR, description updated with both report links
                     mock_post.assert_not_called()
                     mock_patch.assert_called_once()
                     patched_description = mock_patch.call_args.kwargs["json"]["description"]
@@ -665,7 +665,7 @@ def test_sourcecraft_agent_update_about_section(sourcecraft_agent_instance, mock
         with patch("requests.patch", return_value=mock_response) as mock_patch:
             sourcecraft_agent_instance.update_about_section({"description": "Test description"})
 
-            # Assert — called twice: once for base repo, once for fork
+            # Assert - called twice: once for base repo, once for fork
             assert mock_patch.call_count == 2
             for call in mock_patch.call_args_list:
                 _, kwargs = call

--- a/tests/unit/core/git/test_metadata.py
+++ b/tests/unit/core/git/test_metadata.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import patch, ANY
+from unittest.mock import patch
 
 import pytest
 
@@ -15,18 +15,21 @@ LOADER_CLASSES = {
     "github": GitHubMetadataLoader,
     "gitlab": GitLabMetadataLoader,
     "gitverse": GitverseMetadataLoader,
+    "sourcecraft": SourceCraftMetadataLoader,
 }
 
 TOKEN_ENVS = {
     "github": {"GIT_TOKEN": "fake_token", "GITHUB_TOKEN": ""},
     "gitlab": {"GITLAB_TOKEN": "fake_token", "GIT_TOKEN": ""},
     "gitverse": {"GITVERSE_TOKEN": "fake_token", "GIT_TOKEN": ""},
+    "sourcecraft": {"SOURCECRAFT_TOKEN": "fake_token", "GIT_TOKEN": ""},
 }
 
 BASE_URLS = {
     "github": "https://api.github.com/repos/{base}",
     "gitlab": "https://gitlab.com/api/v4/projects/{base}",
     "gitverse": "https://api.gitverse.ru/repos/{base}",
+    "sourcecraft": "https://api.sourcecraft.tech/repos/{base}",
 }
 
 HEADERS = {
@@ -44,10 +47,15 @@ HEADERS = {
         "Content-Type": "application/json",
         "User-Agent": "Mozilla/5.0",
     },
+    "sourcecraft": {
+        "Authorization": "Bearer fake_token",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    },
 }
 
 
-@pytest.mark.parametrize("mock_config_manager", ["github", "gitlab", "gitverse"], indirect=True)
+@pytest.mark.parametrize("mock_config_manager", ["github", "gitlab", "gitverse", "sourcecraft"], indirect=True)
 def test_load_platform_data_success(mock_api_raw_data, mock_requests_response_factory, repo_info):
     # Arrange
     platform, owner, repo_name, repo_url = repo_info
@@ -64,12 +72,13 @@ def test_load_platform_data_success(mock_api_raw_data, mock_requests_response_fa
     expected = loader_class._parse_metadata(raw_data)
     assert result == expected
 
-    base_url = get_base_repo_url(repo_url)
     if platform == "gitlab":
-        base_url = base_url.replace("/", "%2F")
+        base_url = get_base_repo_url(repo_url).replace("/", "%2F")
         expected_url = BASE_URLS["gitlab"].format(base=base_url)
+    elif platform == "sourcecraft":
+        expected_url = BASE_URLS["sourcecraft"].format(base=f"{owner}/{repo_name}")
     else:
-        expected_url = BASE_URLS[platform].format(base=base_url)
+        expected_url = BASE_URLS[platform].format(base=get_base_repo_url(repo_url))
 
     mock_get.assert_called_once_with(
         url=expected_url,
@@ -77,7 +86,7 @@ def test_load_platform_data_success(mock_api_raw_data, mock_requests_response_fa
     )
 
 
-@pytest.mark.parametrize("mock_config_manager", ["github", "gitlab", "gitverse"], indirect=True)
+@pytest.mark.parametrize("mock_config_manager", ["github", "gitlab", "gitverse", "sourcecraft"], indirect=True)
 @pytest.mark.parametrize("status_code", [401, 403, 404, 500])
 def test_load_data_http_errors(status_code, mock_requests_response_factory, repo_info):
     # Arrange
@@ -91,15 +100,7 @@ def test_load_data_http_errors(status_code, mock_requests_response_factory, repo
             with pytest.raises(Exception):
                 loader_class.load_data(repo_url)
 
-
-# ---------------------------------------------------------------------------
-# SourceCraft MetadataLoader — standalone tests (API format differs from other platforms)
-# ---------------------------------------------------------------------------
-
-_SC_REPO_URL = "https://sourcecraft.dev/testorg/testrepo"
-_SC_API_URL = "https://api.sourcecraft.tech/repos/testorg/testrepo"
-_SC_TOKEN_ENV = {"SOURCECRAFT_TOKEN": "fake_sc_token", "GIT_TOKEN": ""}
-
+# Sourcecraft
 
 def _make_sc_raw_data() -> dict:
     return {
@@ -118,34 +119,6 @@ def _make_sc_raw_data() -> dict:
         "organization": {"slug": "testorg"},
         "language": {"name": "Python", "color": "#3572A5"},
     }
-
-
-def test_sourcecraft_load_platform_data_success(mock_requests_response_factory):
-    # Arrange
-    raw_data = _make_sc_raw_data()
-    mock_response = mock_requests_response_factory(status_code=200, json_data=raw_data)
-
-    # Act
-    with patch("osa_tool.core.git.metadata.requests.get", return_value=mock_response) as mock_get:
-        with patch.dict(os.environ, _SC_TOKEN_ENV):
-            result = SourceCraftMetadataLoader._load_platform_data(_SC_REPO_URL, use_token=True)
-
-    # Assert
-    expected = SourceCraftMetadataLoader._parse_metadata(raw_data)
-    assert result == expected
-    mock_get.assert_called_once_with(url=_SC_API_URL, headers=ANY)
-
-
-@pytest.mark.parametrize("status_code", [401, 403, 404, 500])
-def test_sourcecraft_load_data_http_errors(status_code, mock_requests_response_factory):
-    # Arrange
-    mock_response = mock_requests_response_factory(status_code=status_code)
-
-    # Act & Assert
-    with patch("osa_tool.core.git.metadata.requests.get", return_value=mock_response):
-        with patch.dict(os.environ, _SC_TOKEN_ENV):
-            with pytest.raises(Exception):
-                SourceCraftMetadataLoader.load_data(_SC_REPO_URL)
 
 
 def test_sourcecraft_parse_metadata_full_name():

--- a/tests/unit/core/git/test_metadata.py
+++ b/tests/unit/core/git/test_metadata.py
@@ -1,5 +1,5 @@
 import os
-from unittest.mock import patch
+from unittest.mock import patch, ANY
 
 import pytest
 
@@ -7,6 +7,7 @@ from osa_tool.core.git.metadata import (
     GitHubMetadataLoader,
     GitLabMetadataLoader,
     GitverseMetadataLoader,
+    SourceCraftMetadataLoader,
 )
 from osa_tool.utils.utils import get_base_repo_url
 
@@ -89,3 +90,110 @@ def test_load_data_http_errors(status_code, mock_requests_response_factory, repo
         with patch.dict(os.environ, TOKEN_ENVS[platform]):
             with pytest.raises(Exception):
                 loader_class.load_data(repo_url)
+
+
+# ---------------------------------------------------------------------------
+# SourceCraft MetadataLoader — standalone tests (API format differs from other platforms)
+# ---------------------------------------------------------------------------
+
+_SC_REPO_URL = "https://sourcecraft.dev/testorg/testrepo"
+_SC_API_URL = "https://api.sourcecraft.tech/repos/testorg/testrepo"
+_SC_TOKEN_ENV = {"SOURCECRAFT_TOKEN": "fake_sc_token", "GIT_TOKEN": ""}
+
+
+def _make_sc_raw_data() -> dict:
+    return {
+        "name": "testrepo",
+        "slug": "testrepo",
+        "description": "Test repository",
+        "default_branch": "main",
+        "last_updated": "2024-01-01T00:00:00Z",
+        "visibility": "public",
+        "web_url": "https://sourcecraft.dev/testorg/testrepo",
+        "counters": {"forks": "3", "issues": "5"},
+        "clone_url": {
+            "https": "https://git@git.sourcecraft.dev/testorg/testrepo.git",
+            "ssh": "git@git.sourcecraft.dev:testorg/testrepo.git",
+        },
+        "organization": {"slug": "testorg"},
+        "language": {"name": "Python", "color": "#3572A5"},
+    }
+
+
+def test_sourcecraft_load_platform_data_success(mock_requests_response_factory):
+    # Arrange
+    raw_data = _make_sc_raw_data()
+    mock_response = mock_requests_response_factory(status_code=200, json_data=raw_data)
+
+    # Act
+    with patch("osa_tool.core.git.metadata.requests.get", return_value=mock_response) as mock_get:
+        with patch.dict(os.environ, _SC_TOKEN_ENV):
+            result = SourceCraftMetadataLoader._load_platform_data(_SC_REPO_URL, use_token=True)
+
+    # Assert
+    expected = SourceCraftMetadataLoader._parse_metadata(raw_data)
+    assert result == expected
+    mock_get.assert_called_once_with(url=_SC_API_URL, headers=ANY)
+
+
+@pytest.mark.parametrize("status_code", [401, 403, 404, 500])
+def test_sourcecraft_load_data_http_errors(status_code, mock_requests_response_factory):
+    # Arrange
+    mock_response = mock_requests_response_factory(status_code=status_code)
+
+    # Act & Assert
+    with patch("osa_tool.core.git.metadata.requests.get", return_value=mock_response):
+        with patch.dict(os.environ, _SC_TOKEN_ENV):
+            with pytest.raises(Exception):
+                SourceCraftMetadataLoader.load_data(_SC_REPO_URL)
+
+
+def test_sourcecraft_parse_metadata_full_name():
+    # full_name must be org_slug/repo_slug, not just repo_slug
+    result = SourceCraftMetadataLoader._parse_metadata(_make_sc_raw_data())
+    assert result.full_name == "testorg/testrepo"
+
+
+def test_sourcecraft_parse_metadata_issues_url_includes_org():
+    # issues_url must include both org and repo slugs
+    result = SourceCraftMetadataLoader._parse_metadata(_make_sc_raw_data())
+    assert result.issues_url == "https://sourcecraft.dev/testorg/testrepo/issues"
+
+
+def test_sourcecraft_parse_metadata_counters_as_strings():
+    # Counters arrive as strings from the API, should be parsed as ints
+    raw = _make_sc_raw_data()
+    raw["counters"] = {"forks": "7", "issues": "12"}
+    result = SourceCraftMetadataLoader._parse_metadata(raw)
+    assert result.forks_count == 7
+    assert result.open_issues_count == 12
+
+
+def test_sourcecraft_parse_metadata_language_none():
+    # language=None must not raise and should yield empty string
+    raw = _make_sc_raw_data()
+    raw["language"] = None
+    result = SourceCraftMetadataLoader._parse_metadata(raw)
+    assert result.language == ""
+
+
+def test_sourcecraft_parse_metadata_language_empty_dict():
+    # language={} must not raise and should yield empty string
+    raw = _make_sc_raw_data()
+    raw["language"] = {}
+    result = SourceCraftMetadataLoader._parse_metadata(raw)
+    assert result.language == ""
+
+
+def test_sourcecraft_parse_metadata_private_visibility():
+    raw = _make_sc_raw_data()
+    raw["visibility"] = "private"
+    result = SourceCraftMetadataLoader._parse_metadata(raw)
+    assert result.is_private is True
+
+
+def test_sourcecraft_parse_metadata_public_visibility():
+    raw = _make_sc_raw_data()
+    raw["visibility"] = "public"
+    result = SourceCraftMetadataLoader._parse_metadata(raw)
+    assert result.is_private is False

--- a/tests/unit/core/git/test_metadata.py
+++ b/tests/unit/core/git/test_metadata.py
@@ -197,3 +197,31 @@ def test_sourcecraft_parse_metadata_public_visibility():
     raw["visibility"] = "public"
     result = SourceCraftMetadataLoader._parse_metadata(raw)
     assert result.is_private is False
+
+
+def test_sourcecraft_parse_metadata_organization_none():
+    # organization=null must not raise; owner/full_name/issues_url degrade gracefully
+    raw = _make_sc_raw_data()
+    raw["organization"] = None
+    result = SourceCraftMetadataLoader._parse_metadata(raw)
+    assert result.owner == ""
+    assert result.owner_url is None
+    assert result.issues_url == ""
+
+
+def test_sourcecraft_parse_metadata_counters_none():
+    # counters=null must not raise; counts default to 0
+    raw = _make_sc_raw_data()
+    raw["counters"] = None
+    result = SourceCraftMetadataLoader._parse_metadata(raw)
+    assert result.forks_count == 0
+    assert result.open_issues_count == 0
+
+
+def test_sourcecraft_parse_metadata_clone_url_none():
+    # clone_url=null must not raise; URLs default to empty string
+    raw = _make_sc_raw_data()
+    raw["clone_url"] = None
+    result = SourceCraftMetadataLoader._parse_metadata(raw)
+    assert result.clone_url_http == ""
+    assert result.clone_url_ssh == ""

--- a/tests/unit/core/git/test_metadata.py
+++ b/tests/unit/core/git/test_metadata.py
@@ -100,7 +100,9 @@ def test_load_data_http_errors(status_code, mock_requests_response_factory, repo
             with pytest.raises(Exception):
                 loader_class.load_data(repo_url)
 
+
 # Sourcecraft
+
 
 def _make_sc_raw_data() -> dict:
     return {

--- a/tests/unit/operations/codebase/docstring_generation/test_docgen.py
+++ b/tests/unit/operations/codebase/docstring_generation/test_docgen.py
@@ -918,6 +918,7 @@ def test_create_mkdocs_git_workflow_sourcecraft(mock_config_manager, tmp_path):
     assert ci_file.exists(), "ci.yaml was not created"
 
     import yaml
+
     ci_data = yaml.safe_load(ci_file.read_text())
 
     # on: pull_request includes build_docs
@@ -955,6 +956,7 @@ def test_create_mkdocs_git_workflow_sourcecraft_merges_existing_ci(mock_config_m
     sc_dir = tmp_path / ".sourcecraft"
     sc_dir.mkdir()
     import yaml
+
     existing = {
         "on": {
             "push": [{"workflows": ["lint"]}],

--- a/tests/unit/operations/codebase/docstring_generation/test_docgen.py
+++ b/tests/unit/operations/codebase/docstring_generation/test_docgen.py
@@ -903,6 +903,83 @@ async def test_get_project_source_code_with_config(tmp_path, mock_config_manager
     assert result == expected
 
 
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_create_mkdocs_git_workflow_sourcecraft(mock_config_manager, tmp_path):
+    # Arrange
+    docgen = DocGen(mock_config_manager)
+    repo_url = mock_config_manager.get_git_settings().repository
+    full_name = mock_config_manager.get_git_settings().full_name
+
+    # Act
+    docgen.create_mkdocs_git_workflow(repo_url, str(tmp_path))
+
+    # Assert — .sourcecraft/ci.yaml created
+    ci_file = tmp_path / ".sourcecraft" / "ci.yaml"
+    assert ci_file.exists(), "ci.yaml was not created"
+
+    import yaml
+    ci_data = yaml.safe_load(ci_file.read_text())
+
+    # on: pull_request includes build_docs
+    pr_workflows = ci_data["on"]["pull_request"][0]["workflows"]
+    assert "build_docs" in pr_workflows
+
+    # on: push includes deploy_docs with main/master filter
+    push_entries = ci_data["on"]["push"]
+    deploy_entry = next((e for e in push_entries if "deploy_docs" in e.get("workflows", [])), None)
+    assert deploy_entry is not None
+    assert set(deploy_entry["filter"]["branches"]) == {"main", "master"}
+
+    # workflows: build_docs and deploy_docs defined
+    assert "build_docs" in ci_data["workflows"]
+    assert "deploy_docs" in ci_data["workflows"]
+
+    # deploy script has full_name substituted (no {full_name} placeholder left)
+    deploy_cubes = ci_data["workflows"]["deploy_docs"]["tasks"][0]["cubes"]
+    deploy_script = " ".join(deploy_cubes[0]["script"])
+    assert "{full_name}" not in deploy_script
+    assert full_name in deploy_script
+
+    # Assert — .sourcecraft/sites.yaml created
+    sites_file = tmp_path / ".sourcecraft" / "sites.yaml"
+    assert sites_file.exists(), "sites.yaml was not created"
+
+    sites_data = yaml.safe_load(sites_file.read_text())
+    assert sites_data["site"]["ref"] == "release"
+    assert sites_data["site"]["root"] == "."
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_create_mkdocs_git_workflow_sourcecraft_merges_existing_ci(mock_config_manager, tmp_path):
+    # Arrange — pre-existing ci.yaml with lint workflow
+    sc_dir = tmp_path / ".sourcecraft"
+    sc_dir.mkdir()
+    import yaml
+    existing = {
+        "on": {
+            "push": [{"workflows": ["lint"]}],
+            "pull_request": [{"workflows": ["lint"]}],
+        },
+        "workflows": {"lint": {"tasks": [{"name": "lint", "cubes": []}]}},
+    }
+    (sc_dir / "ci.yaml").write_text(yaml.safe_dump(existing))
+
+    docgen = DocGen(mock_config_manager)
+
+    # Act
+    docgen.create_mkdocs_git_workflow(mock_config_manager.get_git_settings().repository, str(tmp_path))
+
+    # Assert — existing lint workflow preserved, mkdocs workflows added
+    ci_data = yaml.safe_load((sc_dir / "ci.yaml").read_text())
+    assert "lint" in ci_data["workflows"]
+    assert "build_docs" in ci_data["workflows"]
+    assert "deploy_docs" in ci_data["workflows"]
+
+    pr_workflows = ci_data["on"]["pull_request"][0]["workflows"]
+    assert "lint" in pr_workflows
+    assert "build_docs" in pr_workflows
+
+
 @pytest.mark.asyncio
 async def test_write_augmented_code_with_config(tmp_path, mock_config_manager):
     # Arrange

--- a/tests/unit/operations/codebase/docstring_generation/test_docgen.py
+++ b/tests/unit/operations/codebase/docstring_generation/test_docgen.py
@@ -947,7 +947,7 @@ def test_create_mkdocs_git_workflow_sourcecraft(mock_config_manager, tmp_path):
 
     sites_data = yaml.safe_load(sites_file.read_text())
     assert sites_data["site"]["ref"] == "release"
-    assert sites_data["site"]["root"] == "."
+    assert "root" not in sites_data["site"]
 
 
 @pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)

--- a/tests/unit/operations/docs/community_docs_generation/test_community.py
+++ b/tests/unit/operations/docs/community_docs_generation/test_community.py
@@ -41,6 +41,25 @@ def test_community_template_builder_init(
     assert builder.bug_issue_to_save.endswith("BUG_ISSUE.md")
 
 
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_community_template_builder_sourcecraft_paths_in_repo_root(
+    mock_config_manager, mock_repository_metadata
+):
+    builder = CommunityTemplateBuilder(mock_config_manager, mock_repository_metadata)
+
+    for attr in (
+        "code_of_conduct_to_save",
+        "security_to_save",
+        "pr_to_save",
+        "docs_issue_to_save",
+        "feature_issue_to_save",
+        "bug_issue_to_save",
+    ):
+        path = getattr(builder, attr)
+        assert ".sourcecraft" not in path, f"{attr} must not be inside .sourcecraft/"
+        assert os.path.dirname(path) == os.path.dirname(builder.code_of_conduct_to_save)
+
+
 def test_build_code_of_conduct(mock_config_manager, mock_repository_metadata, tmp_path, caplog):
     # Arrange
     builder = CommunityTemplateBuilder(mock_config_manager, mock_repository_metadata)

--- a/tests/unit/operations/docs/community_docs_generation/test_community.py
+++ b/tests/unit/operations/docs/community_docs_generation/test_community.py
@@ -42,9 +42,7 @@ def test_community_template_builder_init(
 
 
 @pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
-def test_community_template_builder_sourcecraft_paths_in_repo_root(
-    mock_config_manager, mock_repository_metadata
-):
+def test_community_template_builder_sourcecraft_paths_in_repo_root(mock_config_manager, mock_repository_metadata):
     builder = CommunityTemplateBuilder(mock_config_manager, mock_repository_metadata)
 
     for attr in (

--- a/tests/unit/operations/docs/community_docs_generation/test_contributing.py
+++ b/tests/unit/operations/docs/community_docs_generation/test_contributing.py
@@ -1,6 +1,8 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from osa_tool.operations.docs.community_docs_generation.contributing import ContributingBuilder
 from osa_tool.tools.repository_analysis.sourcerank import SourceRank
 from tests.utils.mocks.repo_trees import get_mock_repo_tree
@@ -56,6 +58,20 @@ def test_guide_property(mock_config_manager, mock_repository_metadata):
     # Assert
     assert builder.url_path in guide_text
     assert mock_repository_metadata.name in guide_text
+    # clone_url must be present - real clone URL, not a hardcoded GitHub URL
+    expected_clone = mock_repository_metadata.clone_url_http or builder.url_path
+    assert expected_clone in guide_text
+    assert "https://github.com/" not in guide_text or "github" in mock_config_manager.get_git_settings().host
+
+
+@pytest.mark.parametrize("mock_config_manager", ["github", "gitlab", "gitverse"], indirect=True)
+def test_guide_property_clone_url_per_platform(mock_config_manager, mock_repository_metadata):
+    builder = ContributingBuilder(mock_config_manager, mock_repository_metadata)
+
+    guide_text = builder.guide
+
+    expected_clone = mock_repository_metadata.clone_url_http or builder.url_path
+    assert expected_clone in guide_text
 
 
 def test_before_pr_property(mock_config_manager, mock_repository_metadata):
@@ -219,3 +235,26 @@ def test_build_handles_exception_and_logs_error(mock_config_manager, mock_reposi
 
         # Assert
         assert "Error while generating CONTRIBUTING.md" in caplog.text
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_contributing_builder_sourcecraft_file_to_save_in_repo_root(
+    mock_config_manager, mock_repository_metadata
+):
+    builder = ContributingBuilder(mock_config_manager, mock_repository_metadata)
+
+    assert builder.file_to_save.endswith("CONTRIBUTING.md")
+    # Must be directly in repo root, not inside a .sourcecraft/ or .github/ subdirectory
+    parent = os.path.basename(os.path.dirname(builder.file_to_save))
+    assert parent != ".sourcecraft"
+    assert parent != ".github"
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_guide_property_contains_clone_url(mock_config_manager, mock_repository_metadata):
+    builder = ContributingBuilder(mock_config_manager, mock_repository_metadata)
+
+    guide_text = builder.guide
+
+    expected_clone_url = mock_repository_metadata.clone_url_http or builder.url_path
+    assert expected_clone_url in guide_text

--- a/tests/unit/operations/docs/community_docs_generation/test_contributing.py
+++ b/tests/unit/operations/docs/community_docs_generation/test_contributing.py
@@ -238,9 +238,7 @@ def test_build_handles_exception_and_logs_error(mock_config_manager, mock_reposi
 
 
 @pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
-def test_contributing_builder_sourcecraft_file_to_save_in_repo_root(
-    mock_config_manager, mock_repository_metadata
-):
+def test_contributing_builder_sourcecraft_file_to_save_in_repo_root(mock_config_manager, mock_repository_metadata):
     builder = ContributingBuilder(mock_config_manager, mock_repository_metadata)
 
     assert builder.file_to_save.endswith("CONTRIBUTING.md")

--- a/tests/unit/operations/docs/readme_generation/inputs/test_dependencies.py
+++ b/tests/unit/operations/docs/readme_generation/inputs/test_dependencies.py
@@ -6,10 +6,12 @@ from tests.utils.mocks.repo_trees import get_mock_repo_tree
 
 def test_extract_from_requirements(tmp_path):
     # Arrange
-    require = textwrap.dedent("""
+    require = textwrap.dedent(
+        """
         numpy>=1.21
         pandas==1.5.0
-        """)
+        """
+    )
     (tmp_path / "requirements.txt").write_text(require)
     extractor = DependencyExtractor(get_mock_repo_tree("WITH_REQUIREMENTS_ONLY"), str(tmp_path))
 
@@ -22,14 +24,16 @@ def test_extract_from_requirements(tmp_path):
 
 def test_extract_from_pyproject_pep621(tmp_path):
     # Arrange
-    pyproj = textwrap.dedent("""
+    pyproj = textwrap.dedent(
+        """
         [project]
         dependencies = [
             "flask>=2.0",
             "requests"
         ]
         requires-python = ">=3.9"
-        """)
+        """
+    )
     (tmp_path / "pyproject.toml").write_text(pyproj)
 
     extractor = DependencyExtractor(get_mock_repo_tree("WITH_PYPROJECT"), str(tmp_path))
@@ -43,12 +47,14 @@ def test_extract_from_pyproject_pep621(tmp_path):
 
 def test_extract_from_pyproject_poetry(tmp_path):
     # Arrange
-    pyproj = textwrap.dedent("""
+    pyproj = textwrap.dedent(
+        """
         [tool.poetry.dependencies]
         python = ">=3.8"
         torch = "^1.12"
         transformers = "^4.21"
-        """)
+        """
+    )
     (tmp_path / "pyproject.toml").write_text(pyproj)
 
     extractor = DependencyExtractor(get_mock_repo_tree("WITH_PYPROJECT"), str(tmp_path))
@@ -64,7 +70,8 @@ def test_extract_from_pyproject_poetry(tmp_path):
 
 def test_extract_from_setup_install_requires(tmp_path):
     # Arrange
-    setup_code = textwrap.dedent("""
+    setup_code = textwrap.dedent(
+        """
         from setuptools import setup
 
         setup(
@@ -75,7 +82,8 @@ def test_extract_from_setup_install_requires(tmp_path):
             ],
             python_requires=">=3.7",
         )
-        """)
+        """
+    )
     (tmp_path / "setup.py").write_text(setup_code, encoding="utf-8")
 
     extractor = DependencyExtractor(get_mock_repo_tree("WITH_SETUP"), str(tmp_path))

--- a/tests/unit/operations/docs/readme_generation/inputs/test_dependencies.py
+++ b/tests/unit/operations/docs/readme_generation/inputs/test_dependencies.py
@@ -6,12 +6,10 @@ from tests.utils.mocks.repo_trees import get_mock_repo_tree
 
 def test_extract_from_requirements(tmp_path):
     # Arrange
-    require = textwrap.dedent(
-        """
+    require = textwrap.dedent("""
         numpy>=1.21
         pandas==1.5.0
-        """
-    )
+        """)
     (tmp_path / "requirements.txt").write_text(require)
     extractor = DependencyExtractor(get_mock_repo_tree("WITH_REQUIREMENTS_ONLY"), str(tmp_path))
 
@@ -24,16 +22,14 @@ def test_extract_from_requirements(tmp_path):
 
 def test_extract_from_pyproject_pep621(tmp_path):
     # Arrange
-    pyproj = textwrap.dedent(
-        """
+    pyproj = textwrap.dedent("""
         [project]
         dependencies = [
             "flask>=2.0",
             "requests"
         ]
         requires-python = ">=3.9"
-        """
-    )
+        """)
     (tmp_path / "pyproject.toml").write_text(pyproj)
 
     extractor = DependencyExtractor(get_mock_repo_tree("WITH_PYPROJECT"), str(tmp_path))
@@ -47,14 +43,12 @@ def test_extract_from_pyproject_pep621(tmp_path):
 
 def test_extract_from_pyproject_poetry(tmp_path):
     # Arrange
-    pyproj = textwrap.dedent(
-        """
+    pyproj = textwrap.dedent("""
         [tool.poetry.dependencies]
         python = ">=3.8"
         torch = "^1.12"
         transformers = "^4.21"
-        """
-    )
+        """)
     (tmp_path / "pyproject.toml").write_text(pyproj)
 
     extractor = DependencyExtractor(get_mock_repo_tree("WITH_PYPROJECT"), str(tmp_path))
@@ -70,8 +64,7 @@ def test_extract_from_pyproject_poetry(tmp_path):
 
 def test_extract_from_setup_install_requires(tmp_path):
     # Arrange
-    setup_code = textwrap.dedent(
-        """
+    setup_code = textwrap.dedent("""
         from setuptools import setup
 
         setup(
@@ -82,8 +75,7 @@ def test_extract_from_setup_install_requires(tmp_path):
             ],
             python_requires=">=3.7",
         )
-        """
-    )
+        """)
     (tmp_path / "setup.py").write_text(setup_code, encoding="utf-8")
 
     extractor = DependencyExtractor(get_mock_repo_tree("WITH_SETUP"), str(tmp_path))

--- a/tests/unit/operations/docs/readme_generation/pipeline/nodes/test_context_collector.py
+++ b/tests/unit/operations/docs/readme_generation/pipeline/nodes/test_context_collector.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from osa_tool.core.models.llm_output_models import LlmTextOutput
 from osa_tool.operations.docs.readme_generation.pipeline.llm_schemas import KeyFilesLLMOutput
@@ -258,3 +258,55 @@ def test_context_collector_node_returns_all_expected_keys(
     assert ctx.readme_analysis == "readme analysis result"
     assert ctx.pdf_content is None
     assert ctx.article_analysis is None
+
+
+@patch("osa_tool.operations.docs.readme_generation.pipeline.nodes.context_collector.SourceRank")
+@patch("osa_tool.operations.docs.readme_generation.pipeline.nodes.context_collector.extract_readme_content")
+@patch("osa_tool.operations.docs.readme_generation.pipeline.nodes.context_collector.extract_example_paths")
+@patch("osa_tool.operations.docs.readme_generation.pipeline.nodes.context_collector.read_file")
+@patch("osa_tool.operations.docs.readme_generation.pipeline.nodes.context_collector._run_parallel_analyses")
+@patch("osa_tool.operations.docs.readme_generation.pipeline.nodes.context_collector.PromptBuilder")
+def test_repo_analysis_prompt_receives_clone_url_http(
+    mock_prompt_builder,
+    mock_parallel,
+    mock_read_file,
+    mock_examples,
+    mock_extract_readme,
+    mock_sourcerank_cls,
+    mock_config_manager,
+    mock_repository_metadata,
+):
+    # Arrange
+    mock_repository_metadata.clone_url_http = "https://git.sourcecraft.dev/org/repo.git"
+    mock_sourcerank_cls.return_value.tree = "README.md\nsrc\nsrc/main.py"
+    mock_extract_readme.return_value = "# Test Project"
+    mock_examples.return_value = []
+    mock_read_file.return_value = "print('hello')"
+    mock_parallel.return_value = ("readme analysis result", None)
+    mock_prompt_builder.render.return_value = "rendered prompt"
+
+    mock_model_handler = MagicMock()
+    mock_model_handler.send_and_parse.side_effect = [
+        KeyFilesLLMOutput(key_files=["src/main.py"]),
+        LlmTextOutput(text="repo analysis result"),
+    ]
+
+    mock_context = MagicMock()
+    mock_context.config_manager = mock_config_manager
+    mock_context.model_handler = mock_model_handler
+    mock_context.prompts = mock_config_manager.get_prompts()
+    mock_context.metadata = mock_repository_metadata
+
+    state = ReadmeState(repo_url="https://sourcecraft.dev/org/repo")
+
+    # Act
+    context_collector_node(state, mock_context)
+
+    # Assert: repo_analysis render call must include clone_url_http
+    render_calls = mock_prompt_builder.render.call_args_list
+    repo_analysis_call = next(
+        (c for c in render_calls if "clone_url_http" in c.kwargs),
+        None,
+    )
+    assert repo_analysis_call is not None, "PromptBuilder.render was not called with clone_url_http"
+    assert repo_analysis_call.kwargs["clone_url_http"] == "https://git.sourcecraft.dev/org/repo.git"

--- a/tests/unit/operations/docs/readme_generation/pipeline/nodes/test_deterministic_builder.py
+++ b/tests/unit/operations/docs/readme_generation/pipeline/nodes/test_deterministic_builder.py
@@ -1,0 +1,79 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from osa_tool.operations.docs.readme_generation.pipeline.nodes.deterministic_builder import _DeterministicSections
+
+
+def _make_builder(mock_config_manager, mock_repository_metadata):
+    """Construct _DeterministicSections with a minimal mocked ReadmeContext."""
+    context = MagicMock()
+    context.config_manager = mock_config_manager
+    context.metadata = mock_repository_metadata
+    with patch("osa_tool.operations.docs.readme_generation.pipeline.nodes.deterministic_builder.SourceRank"):
+        builder = _DeterministicSections(context)
+    builder._sr = MagicMock()
+    builder._sr.citation_presence.return_value = False
+    builder._sr.tree = []
+    return builder, context
+
+
+def test_citation_fallback_uses_created_at_year(mock_config_manager, mock_repository_metadata):
+    # Arrange - metadata has a valid ISO created_at
+    mock_repository_metadata.created_at = "2021-04-15T10:00:00Z"
+    mock_repository_metadata.owner = "testowner"
+    builder, context = _make_builder(mock_config_manager, mock_repository_metadata)
+    builder._extract_citation_from_readme = MagicMock(return_value="")
+
+    # Act
+    content = builder.citation()
+
+    # Assert
+    assert "2021" in content
+    assert "testowner" in content
+
+
+def test_citation_fallback_year_when_created_at_empty(mock_config_manager, mock_repository_metadata):
+    # Arrange - SourceCraft doesn't return created_at
+    mock_repository_metadata.created_at = ""
+    builder, context = _make_builder(mock_config_manager, mock_repository_metadata)
+    builder._extract_citation_from_readme = MagicMock(return_value="")
+
+    # Act
+    content = builder.citation()
+
+    # Assert
+    current_year = str(datetime.now().year)
+    assert f"year = {{{current_year}}}" in content
+    assert "year = {}" not in content
+
+
+def test_citation_fallback_year_when_created_at_none(mock_config_manager, mock_repository_metadata):
+    # Arrange
+    mock_repository_metadata.created_at = None
+    builder, context = _make_builder(mock_config_manager, mock_repository_metadata)
+    builder._extract_citation_from_readme = MagicMock(return_value="")
+
+    # Act
+    content = builder.citation()
+
+    # Assert
+    current_year = str(datetime.now().year)
+    assert current_year in content
+    assert "year = {}" not in content
+
+
+def test_citation_url_has_no_git_suffix(mock_config_manager, mock_repository_metadata):
+    # Arrange
+    mock_repository_metadata.created_at = "2022-01-01T00:00:00Z"
+    builder, context = _make_builder(mock_config_manager, mock_repository_metadata)
+    builder._extract_citation_from_readme = MagicMock(return_value="")
+    repo_url = mock_config_manager.get_git_settings().repository
+
+    # Act
+    content = builder.citation()
+
+    # Assert
+    assert f"{repo_url}.git" not in content
+    assert repo_url in content

--- a/tests/unit/scheduler/test_workflow_generator.py
+++ b/tests/unit/scheduler/test_workflow_generator.py
@@ -102,9 +102,9 @@ def test_tests_workflow_one_cube_per_version(tmp_path):
     cubes = config["workflows"]["tests"]["tasks"][0]["cubes"]
     assert len(cubes) == 3
     cube_names = {c["name"] for c in cubes}
-    assert "pytest-3.9" in cube_names
-    assert "pytest-3.10" in cube_names
-    assert "pytest-3.11" in cube_names
+    assert "pytest-3-9" in cube_names
+    assert "pytest-3-10" in cube_names
+    assert "pytest-3-11" in cube_names
 
 
 def test_tests_cube_uses_correct_docker_image(tmp_path):

--- a/tests/unit/scheduler/test_workflow_generator.py
+++ b/tests/unit/scheduler/test_workflow_generator.py
@@ -1,0 +1,235 @@
+import pytest
+import yaml
+
+from osa_tool.config.settings import WorkflowSettings
+from osa_tool.core.models.task import TaskStatus
+from osa_tool.operations.codebase.workflow_generation.workflow_generator import SourceCraftWorkflowGenerator
+from osa_tool.scheduler.plan import Plan
+
+
+def _settings(**kwargs) -> WorkflowSettings:
+    defaults = dict(
+        include_black=False,
+        include_tests=False,
+        include_pep8=False,
+        include_autopep8=False,
+        include_fix_pep8=False,
+        include_pypi=False,
+        python_versions=["3.11"],
+        pep8_tool="flake8",
+        use_poetry=False,
+        branches=[],
+        codecov_token=False,
+        include_codecov=False,
+    )
+    defaults.update(kwargs)
+    return WorkflowSettings(**defaults)
+
+
+def _load_ci(tmp_path) -> dict:
+    with open(tmp_path / "ci.yaml") as f:
+        return yaml.safe_load(f)
+
+
+# ---------------------------------------------------------------------------
+# Basic generation
+# ---------------------------------------------------------------------------
+
+
+def test_no_flags_returns_empty(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    result = gen.generate_selected_jobs(_settings(), plan=None)
+    assert result == []
+    assert not (tmp_path / "ci.yaml").exists()
+
+
+def test_any_flag_creates_ci_yaml(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    result = gen.generate_selected_jobs(_settings(include_black=True), plan=None)
+    assert len(result) == 1
+    assert (tmp_path / "ci.yaml").exists()
+
+
+# ---------------------------------------------------------------------------
+# Lint workflow
+# ---------------------------------------------------------------------------
+
+
+def test_black_cube_in_lint_workflow(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_black=True), plan=None)
+    config = _load_ci(tmp_path)
+    cubes = config["workflows"]["lint"]["tasks"][0]["cubes"]
+    assert any(c["name"] == "black" for c in cubes)
+
+
+def test_pep8_flake8_cube_in_lint_workflow(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_pep8=True, pep8_tool="flake8"), plan=None)
+    config = _load_ci(tmp_path)
+    cubes = config["workflows"]["lint"]["tasks"][0]["cubes"]
+    assert any(c["name"] == "flake8" for c in cubes)
+
+
+def test_pep8_pylint_cube_in_lint_workflow(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_pep8=True, pep8_tool="pylint"), plan=None)
+    config = _load_ci(tmp_path)
+    cubes = config["workflows"]["lint"]["tasks"][0]["cubes"]
+    assert any(c["name"] == "pylint" for c in cubes)
+
+
+def test_autopep8_cube_in_lint_workflow(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_autopep8=True), plan=None)
+    config = _load_ci(tmp_path)
+    cubes = config["workflows"]["lint"]["tasks"][0]["cubes"]
+    assert any(c["name"] == "autopep8" for c in cubes)
+
+
+def test_fix_pep8_cube_in_lint_workflow(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_fix_pep8=True), plan=None)
+    config = _load_ci(tmp_path)
+    cubes = config["workflows"]["lint"]["tasks"][0]["cubes"]
+    assert any(c["name"] == "fix-pep8" for c in cubes)
+
+
+def test_combined_lint_cubes(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_black=True, include_pep8=True), plan=None)
+    config = _load_ci(tmp_path)
+    cubes = config["workflows"]["lint"]["tasks"][0]["cubes"]
+    cube_names = {c["name"] for c in cubes}
+    assert "black" in cube_names
+    assert "flake8" in cube_names
+
+
+# ---------------------------------------------------------------------------
+# Tests workflow
+# ---------------------------------------------------------------------------
+
+
+def test_tests_workflow_one_cube_per_version(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_tests=True, python_versions=["3.9", "3.10", "3.11"]), plan=None)
+    config = _load_ci(tmp_path)
+    cubes = config["workflows"]["tests"]["tasks"][0]["cubes"]
+    assert len(cubes) == 3
+    cube_names = {c["name"] for c in cubes}
+    assert "pytest-3.9" in cube_names
+    assert "pytest-3.10" in cube_names
+    assert "pytest-3.11" in cube_names
+
+
+def test_tests_cube_uses_correct_docker_image(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_tests=True, python_versions=["3.10"]), plan=None)
+    config = _load_ci(tmp_path)
+    cube = config["workflows"]["tests"]["tasks"][0]["cubes"][0]
+    assert "python:3.10" in cube["image"]
+
+
+# ---------------------------------------------------------------------------
+# Publish workflow
+# ---------------------------------------------------------------------------
+
+
+def test_publish_workflow_created(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_pypi=True), plan=None)
+    config = _load_ci(tmp_path)
+    assert "publish" in config["workflows"]
+
+
+def test_publish_triggered_on_version_tags(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_pypi=True), plan=None)
+    config = _load_ci(tmp_path)
+    push_entries = config["on"]["push"]
+    tag_entry = next((e for e in push_entries if e.get("filter", {}).get("tags")), None)
+    assert tag_entry is not None
+    assert "*.*.*" in tag_entry["filter"]["tags"]
+
+
+def test_publish_with_poetry(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_pypi=True, use_poetry=True), plan=None)
+    config = _load_ci(tmp_path)
+    cube = config["workflows"]["publish"]["tasks"][0]["cubes"][0]
+    assert any("poetry" in step for step in cube["script"])
+
+
+def test_publish_with_twine(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_pypi=True, use_poetry=False), plan=None)
+    config = _load_ci(tmp_path)
+    cube = config["workflows"]["publish"]["tasks"][0]["cubes"][0]
+    assert any("twine" in step for step in cube["script"])
+
+
+# ---------------------------------------------------------------------------
+# Triggers (on: section)
+# ---------------------------------------------------------------------------
+
+
+def test_push_and_pull_request_triggers_for_lint(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_black=True), plan=None)
+    config = _load_ci(tmp_path)
+    assert "push" in config["on"]
+    assert "pull_request" in config["on"]
+
+
+def test_branch_filter_applied_when_branches_set(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_black=True, branches=["main", "dev"]), plan=None)
+    config = _load_ci(tmp_path)
+    push_entry = config["on"]["push"][0]
+    assert "filter" in push_entry
+    assert "main" in push_entry["filter"]["branches"]
+
+
+def test_no_branch_filter_when_branches_empty(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_black=True, branches=[]), plan=None)
+    config = _load_ci(tmp_path)
+    push_entry = config["on"]["push"][0]
+    assert "filter" not in push_entry
+
+
+# ---------------------------------------------------------------------------
+# YAML quality: no anchors
+# ---------------------------------------------------------------------------
+
+
+def test_no_yaml_anchors_in_output(tmp_path):
+    # PyYAML must not produce &id001/*id001 anchors (was a bug with shared list references)
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_black=True, include_tests=True), plan=None)
+    content = (tmp_path / "ci.yaml").read_text()
+    assert "&id" not in content
+    assert "*id" not in content
+
+
+# ---------------------------------------------------------------------------
+# Plan integration
+# ---------------------------------------------------------------------------
+
+
+def test_plan_tasks_marked_done(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    plan = Plan({"include_black": True, "include_pep8": True, "include_tests": True})
+    gen.generate_selected_jobs(
+        _settings(include_black=True, include_pep8=True, include_tests=True),
+        plan=plan,
+    )
+    assert plan.tasks["include_black"] == TaskStatus.COMPLETED
+    assert plan.tasks["include_pep8"] == TaskStatus.COMPLETED
+    assert plan.tasks["include_tests"] == TaskStatus.COMPLETED
+
+
+def test_plan_none_does_not_raise(tmp_path):
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_black=True), plan=None)
+    assert (tmp_path / "ci.yaml").exists()

--- a/tests/unit/scheduler/test_workflow_generator.py
+++ b/tests/unit/scheduler/test_workflow_generator.py
@@ -31,11 +31,6 @@ def _load_ci(tmp_path) -> dict:
         return yaml.safe_load(f)
 
 
-# ---------------------------------------------------------------------------
-# Basic generation
-# ---------------------------------------------------------------------------
-
-
 def test_no_flags_returns_empty(tmp_path):
     gen = SourceCraftWorkflowGenerator(str(tmp_path))
     result = gen.generate_selected_jobs(_settings(), plan=None)
@@ -48,11 +43,6 @@ def test_any_flag_creates_ci_yaml(tmp_path):
     result = gen.generate_selected_jobs(_settings(include_black=True), plan=None)
     assert len(result) == 1
     assert (tmp_path / "ci.yaml").exists()
-
-
-# ---------------------------------------------------------------------------
-# Lint workflow
-# ---------------------------------------------------------------------------
 
 
 def test_black_cube_in_lint_workflow(tmp_path):
@@ -105,11 +95,6 @@ def test_combined_lint_cubes(tmp_path):
     assert "flake8" in cube_names
 
 
-# ---------------------------------------------------------------------------
-# Tests workflow
-# ---------------------------------------------------------------------------
-
-
 def test_tests_workflow_one_cube_per_version(tmp_path):
     gen = SourceCraftWorkflowGenerator(str(tmp_path))
     gen.generate_selected_jobs(_settings(include_tests=True, python_versions=["3.9", "3.10", "3.11"]), plan=None)
@@ -128,11 +113,6 @@ def test_tests_cube_uses_correct_docker_image(tmp_path):
     config = _load_ci(tmp_path)
     cube = config["workflows"]["tests"]["tasks"][0]["cubes"][0]
     assert "python:3.10" in cube["image"]
-
-
-# ---------------------------------------------------------------------------
-# Publish workflow
-# ---------------------------------------------------------------------------
 
 
 def test_publish_workflow_created(tmp_path):
@@ -168,11 +148,6 @@ def test_publish_with_twine(tmp_path):
     assert any("twine" in step for step in cube["script"])
 
 
-# ---------------------------------------------------------------------------
-# Triggers (on: section)
-# ---------------------------------------------------------------------------
-
-
 def test_push_and_pull_request_triggers_for_lint(tmp_path):
     gen = SourceCraftWorkflowGenerator(str(tmp_path))
     gen.generate_selected_jobs(_settings(include_black=True), plan=None)
@@ -198,11 +173,6 @@ def test_no_branch_filter_when_branches_empty(tmp_path):
     assert "filter" not in push_entry
 
 
-# ---------------------------------------------------------------------------
-# YAML quality: no anchors
-# ---------------------------------------------------------------------------
-
-
 def test_no_yaml_anchors_in_output(tmp_path):
     # PyYAML must not produce &id001/*id001 anchors (was a bug with shared list references)
     gen = SourceCraftWorkflowGenerator(str(tmp_path))
@@ -210,11 +180,6 @@ def test_no_yaml_anchors_in_output(tmp_path):
     content = (tmp_path / "ci.yaml").read_text()
     assert "&id" not in content
     assert "*id" not in content
-
-
-# ---------------------------------------------------------------------------
-# Plan integration
-# ---------------------------------------------------------------------------
 
 
 def test_plan_tasks_marked_done(tmp_path):

--- a/tests/unit/scheduler/test_workflow_generator.py
+++ b/tests/unit/scheduler/test_workflow_generator.py
@@ -148,6 +148,44 @@ def test_publish_with_twine(tmp_path):
     assert any("twine" in step for step in cube["script"])
 
 
+def test_generate_selected_jobs_preserves_existing_workflows(tmp_path):
+    """Existing docs workflows (build_docs, deploy_docs) must survive a second generate call."""
+    # Arrange: ci.yaml already has lint/tests + docs workflows from create_mkdocs_git_workflow
+    existing = {
+        "on": {
+            "push": [
+                {"workflows": ["lint", "tests"]},
+                {"workflows": ["deploy_docs"], "filter": {"branches": ["main"]}},
+            ],
+            "pull_request": [{"workflows": ["lint", "tests", "build_docs"]}],
+        },
+        "workflows": {
+            "lint": {"tasks": []},
+            "tests": {"tasks": []},
+            "build_docs": {"tasks": [{"name": "build_docs", "cubes": []}]},
+            "deploy_docs": {"tasks": [{"name": "deploy_docs", "cubes": []}]},
+        },
+    }
+    ci_path = tmp_path / "ci.yaml"
+    with open(ci_path, "w") as f:
+        yaml.dump(existing, f)
+
+    # Act: workflow_manager regenerates lint/tests (simulates normal OSA run)
+    gen = SourceCraftWorkflowGenerator(str(tmp_path))
+    gen.generate_selected_jobs(_settings(include_black=True, include_tests=True), plan=None)
+
+    # Assert: docs workflows must still be present
+    config = _load_ci(tmp_path)
+    assert "build_docs" in config["workflows"], "build_docs was lost after second generate"
+    assert "deploy_docs" in config["workflows"], "deploy_docs was lost after second generate"
+    pr_wfs = config["on"]["pull_request"][0]["workflows"]
+    assert "build_docs" in pr_wfs, "build_docs disappeared from pull_request trigger"
+    push_entries = config["on"]["push"]
+    assert any(
+        "deploy_docs" in e.get("workflows", []) for e in push_entries
+    ), "deploy_docs disappeared from push trigger"
+
+
 def test_push_and_pull_request_triggers_for_lint(tmp_path):
     gen = SourceCraftWorkflowGenerator(str(tmp_path))
     gen.generate_selected_jobs(_settings(include_black=True), plan=None)

--- a/tests/unit/scheduler/test_workflow_manager.py
+++ b/tests/unit/scheduler/test_workflow_manager.py
@@ -253,10 +253,6 @@ def test_gitverse_locate_workflow_path_fallback_to_github(mock_config_manager, m
         assert ".github/workflows" in manager.workflow_path.replace("\\", "/")
 
 
-# ---------------------------------------------------------------------------
-# SourceCraft WorkflowManager
-# ---------------------------------------------------------------------------
-
 
 @pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
 def test_sourcecraft_locate_workflow_path_exists(mock_config_manager, mock_repository_metadata, mock_args):

--- a/tests/unit/scheduler/test_workflow_manager.py
+++ b/tests/unit/scheduler/test_workflow_manager.py
@@ -253,7 +253,6 @@ def test_gitverse_locate_workflow_path_fallback_to_github(mock_config_manager, m
         assert ".github/workflows" in manager.workflow_path.replace("\\", "/")
 
 
-
 @pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
 def test_sourcecraft_locate_workflow_path_exists(mock_config_manager, mock_repository_metadata, mock_args):
     # Arrange

--- a/tests/unit/scheduler/test_workflow_manager.py
+++ b/tests/unit/scheduler/test_workflow_manager.py
@@ -293,9 +293,15 @@ def test_sourcecraft_locate_workflow_path_missing(mock_config_manager, mock_repo
 
 
 @pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
-def test_sourcecraft_find_existing_jobs_with_jobs_key(mock_config_manager, mock_repository_metadata, mock_args):
-    # Arrange — ci.yaml uses GitHub-like jobs: section
-    yaml_content = {"jobs": {"lint": {}, "tests": {}}}
+def test_sourcecraft_find_existing_jobs_native_format(mock_config_manager, mock_repository_metadata, mock_args):
+    # Arrange — actual SourceCraft ci.yaml format produced by SourceCraftWorkflowGenerator
+    yaml_content = {
+        "on": {"push": [{"workflows": ["lint", "tests"]}]},
+        "workflows": {
+            "lint": {"tasks": [{"name": "lint", "cubes": []}]},
+            "tests": {"tasks": [{"name": "tests", "cubes": []}]},
+        },
+    }
     with (
         patch("osa_tool.scheduler.workflow_manager.os.path.isfile", return_value=True),
         patch("osa_tool.scheduler.workflow_manager.open", mock_open(read_data=yaml.dump(yaml_content))),
@@ -315,14 +321,9 @@ def test_sourcecraft_find_existing_jobs_with_jobs_key(mock_config_manager, mock_
 
 
 @pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
-def test_sourcecraft_find_existing_jobs_flat_structure(mock_config_manager, mock_repository_metadata, mock_args):
-    # Arrange — flat ci.yaml without a jobs: key (SourceCraft native format)
-    yaml_content = {
-        "image": "python:3.11",
-        "variables": {"ENV": "test"},
-        "lint": {"script": ["flake8 ."]},
-        "tests": {"script": ["pytest"]},
-    }
+def test_sourcecraft_find_existing_jobs_unknown_format(mock_config_manager, mock_repository_metadata, mock_args):
+    # Arrange — unrecognized ci.yaml structure (no workflows: key)
+    yaml_content = {"some_key": {"value": 1}}
     with (
         patch("osa_tool.scheduler.workflow_manager.os.path.isfile", return_value=True),
         patch("osa_tool.scheduler.workflow_manager.open", mock_open(read_data=yaml.dump(yaml_content))),
@@ -337,8 +338,5 @@ def test_sourcecraft_find_existing_jobs_flat_structure(mock_config_manager, mock
         # Act
         jobs = manager._find_existing_jobs()
 
-        # Assert — special keys excluded, only real job dicts kept
-        assert "image" not in jobs
-        assert "variables" not in jobs
-        assert "lint" in jobs
-        assert "tests" in jobs
+        # Assert
+        assert jobs == set()

--- a/tests/unit/scheduler/test_workflow_manager.py
+++ b/tests/unit/scheduler/test_workflow_manager.py
@@ -8,6 +8,7 @@ from osa_tool.scheduler.workflow_manager import (
     GitHubWorkflowManager,
     GitLabWorkflowManager,
     GitverseWorkflowManager,
+    SourceCraftWorkflowManager,
 )
 from osa_tool.tools.repository_analysis.sourcerank import SourceRank
 
@@ -250,3 +251,94 @@ def test_gitverse_locate_workflow_path_fallback_to_github(mock_config_manager, m
         # Assert
         assert manager.workflow_path is not None
         assert ".github/workflows" in manager.workflow_path.replace("\\", "/")
+
+
+# ---------------------------------------------------------------------------
+# SourceCraft WorkflowManager
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_locate_workflow_path_exists(mock_config_manager, mock_repository_metadata, mock_args):
+    # Arrange
+    with (
+        patch("osa_tool.scheduler.workflow_manager.os.path.isfile", return_value=True),
+        patch("osa_tool.scheduler.workflow_manager.open", mock_open()),
+        patch("osa_tool.scheduler.workflow_manager.yaml.safe_load", return_value={}),
+    ):
+        manager = SourceCraftWorkflowManager(
+            repo_url=mock_config_manager.config.git.repository,
+            metadata=mock_repository_metadata,
+            args=mock_args,
+        )
+
+        # Assert
+        assert manager.workflow_path is not None
+        assert manager.workflow_path.endswith("ci.yaml")
+        assert ".sourcecraft" in manager.workflow_path.replace("\\", "/")
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_locate_workflow_path_missing(mock_config_manager, mock_repository_metadata, mock_args):
+    # Arrange
+    with patch("osa_tool.scheduler.workflow_manager.os.path.isfile", return_value=False):
+        manager = SourceCraftWorkflowManager(
+            repo_url=mock_config_manager.config.git.repository,
+            metadata=mock_repository_metadata,
+            args=mock_args,
+        )
+
+        # Assert
+        assert manager.workflow_path is None
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_find_existing_jobs_with_jobs_key(mock_config_manager, mock_repository_metadata, mock_args):
+    # Arrange — ci.yaml uses GitHub-like jobs: section
+    yaml_content = {"jobs": {"lint": {}, "tests": {}}}
+    with (
+        patch("osa_tool.scheduler.workflow_manager.os.path.isfile", return_value=True),
+        patch("osa_tool.scheduler.workflow_manager.open", mock_open(read_data=yaml.dump(yaml_content))),
+        patch("osa_tool.scheduler.workflow_manager.yaml.safe_load", return_value=yaml_content),
+    ):
+        manager = SourceCraftWorkflowManager(
+            repo_url=mock_config_manager.config.git.repository,
+            metadata=mock_repository_metadata,
+            args=mock_args,
+        )
+
+        # Act
+        jobs = manager._find_existing_jobs()
+
+        # Assert
+        assert jobs == {"lint", "tests"}
+
+
+@pytest.mark.parametrize("mock_config_manager", ["sourcecraft"], indirect=True)
+def test_sourcecraft_find_existing_jobs_flat_structure(mock_config_manager, mock_repository_metadata, mock_args):
+    # Arrange — flat ci.yaml without a jobs: key (SourceCraft native format)
+    yaml_content = {
+        "image": "python:3.11",
+        "variables": {"ENV": "test"},
+        "lint": {"script": ["flake8 ."]},
+        "tests": {"script": ["pytest"]},
+    }
+    with (
+        patch("osa_tool.scheduler.workflow_manager.os.path.isfile", return_value=True),
+        patch("osa_tool.scheduler.workflow_manager.open", mock_open(read_data=yaml.dump(yaml_content))),
+        patch("osa_tool.scheduler.workflow_manager.yaml.safe_load", return_value=yaml_content),
+    ):
+        manager = SourceCraftWorkflowManager(
+            repo_url=mock_config_manager.config.git.repository,
+            metadata=mock_repository_metadata,
+            args=mock_args,
+        )
+
+        # Act
+        jobs = manager._find_existing_jobs()
+
+        # Assert — special keys excluded, only real job dicts kept
+        assert "image" not in jobs
+        assert "variables" not in jobs
+        assert "lint" in jobs
+        assert "tests" in jobs


### PR DESCRIPTION
## Добавлено
- Агент для работы с репозиторием: клонирование, форк, создание веток, коммит, пуш, создание и обновление PR. SC разделяет веб-интерфейс (sourcecraft.dev) и Git-сервер (git.sourcecraft.dev). При клонировании с токеном URL переписывается: https://git:TOKEN@git.sourcecraft.dev/org/repo.git.
- Генерирум .sourcecraft/ci.yaml в нативном формате CI SC. Формат отличается от GitHub - вместо jobs здесь: workflows -> tasks -> cubes, каждый cube задаёт Docker-образ и список команд. Поддерживает black, pytest (с матрицей Python-версий), flake8/pylint, autopep8, PyPI publish.
- Исправил parse_folder_name. Без этого фикса папка клонированного репозитория называлась https___sourcecraft.dev_org_repo вместо repo. Добавлен regex-паттерн для SourceCraft.

## Особенности SC
- Нету эндпоинта постановки звезды на репо (так что и тут не реализовано)
- Счётчик звёзд (stars_count), дата создания (created_at), размер (size_kb) - всегда 0 / пустая строка: эти поля отсутствуют в ответе API
- Теги и топики пустой список, т.к. не возвращаются базовым эндпоинтом репозитория
- Обновление топиков - только описание, т.к. PATCH-эндпоинт принимает только description, без тегов
- Валидация топиков возвращает всё как есть. (также нет в API)
- URL контрибьюторов возвращает None (также нет в API)

Пример:
https://sourcecraft.dev/alexshiinov/osa-test-2