### PR TITLE
Feature/improve readme generation

### DIFF
--- a/osa_tool/config/prompts/readme/prompts.toml
+++ b/osa_tool/config/prompts/readme/prompts.toml
@@ -190,37 +190,50 @@ self_eval = """
 TASK:
 Evaluate the generated README and decide whether to stop or run targeted regeneration.
 
-Score the README on a scale of 1-10 based on:
-- Completeness: does it cover all essential sections
-- Accuracy: does it reflect the repository correctly
-- Clarity: is it well-written and easy to follow
-- Structure: proper markdown formatting, logical flow
-- User request alignment: does it address what the user asked for (if applicable)
+Assess along these dimensions (no numeric score in your output):
+- Completeness: essential sections present for this repo
+- Accuracy: matches repository analysis and does not invent facts
+- Clarity: readable and scannable for developers
+- Structure: sound Markdown and logical flow
+- User request alignment: satisfies the user request when one was given
+
+SEVERITY (each issue must use exactly one):
+- "blocker": wrong repo, fabricated commands/paths, broken Markdown, contradicts analysis, or fails the user request
+- "major": materially misleading, missing critical install/run/API steps that belong in this README, or large clarity gaps
+- "minor": typos, wording polish, optional structure tweaks, or small gaps that do not block publication
 
 OUTPUT:
 Return a JSON object:
 
 {{
-    "score": 6,
-    "issues": ["issue 1 description", "issue 2 description"],
-    "should_stop": true,
+    "issues": [
+        {{"severity": "major", "description": "short concrete defect"}},
+        {{"severity": "minor", "description": "optional polish item"}}
+    ],
+    "should_stop": false,
     "sections_to_rerun": [],
-    "section_feedback": {{}}
+    "section_feedback": {{}},
+    "quality_notes": "optional one-line summary for logs only"
 }}
 
+- "issues": list every **blocker** and **major** defect you find; add **minor** items when useful. Use [] only if
+  there are genuinely no defects (rare—assume drafts usually need at least small fixes unless evidence says otherwise).
 - "sections_to_rerun": internal section names from **PLANNED SECTION NAMES** below that need regeneration (LLM prose
   sections only, e.g. "overview", "getting_started"). Use [] if a whole-document patch is enough.
 - "section_feedback": map section internal name -> short instructions for that section's generator (concrete, actionable).
   Omit keys you do not want to rerun.
 
-Set "should_stop" to true if the README is good enough (score >= 8) or if remaining issues are minor.
+Set "should_stop" to true only when:
+- "issues" contains **no** "blocker" or "major" entries, **and**
+- "sections_to_rerun" is empty (if any section still needs regeneration, list it and set should_stop to false), **and**
+- any remaining "minor" issues are optional to fix before publication.
 
 RULES:
 - Report issues as concrete defects, not preferences.
 - Prefer section reruns only when defects are clearly localized to specific sections.
 - If multiple sections repeat the same flaw, mention root cause once and map precise feedback per affected section.
 - Never include section names outside PLANNED SECTION NAMES.
-- Keep issue phrasing short and actionable.
+- Keep each issue "description" short and actionable.
 - If **INTENT SCOPE** is `partial` or **ASSEMBLY MODE** is `merge_existing`, prefer `sections_to_rerun` for
   localized defects; avoid listing whole-document rewrite issues unless the defect is global (broken markdown,
   wrong repository, contradictory title).

--- a/osa_tool/config/prompts/readme/prompts.toml
+++ b/osa_tool/config/prompts/readme/prompts.toml
@@ -479,15 +479,20 @@ RULES:
 - Escape any backslashes in JSON strings so the output is valid JSON (double backslashes for Windows paths).
 - If improving an existing section, keep accurate facts; drop marketing filler and speculative claims.
 - Keep output concise and scannable; avoid repeated claims across paragraphs/bullets.
-- Prefer developer-actionable wording and concrete repository anchors (paths, symbols, commands).
+- Prefer developer-actionable wording. Use concrete repository anchors (paths, symbols, commands) only where
+  section-specific rules allow (e.g. getting_started, examples); for overview and core_features, describe
+  capabilities without naming source files—follow section-specific constraints below.
 
 SECTION-SPECIFIC CONSTRAINTS (apply when section internal name matches):
-- overview: 1-3 short paragraphs only. No bullet lists. Do NOT enumerate libraries or dependencies by name; you may
-  say "Python" once or refer readers to Installation / requirements. Focus on what the repo does and name real
-  entry-point files from the context.
-- core_features: at most 5 bullets. Each bullet must cite at least one concrete file name or function/class symbol
-  visible in the context. Do NOT add bullets that only restate the dependency stack, IDE tooling, type hints,
-  "clean code", "rich libraries", persistence alone, or other generic claims without a specific repo artifact.
+- overview: 1-3 short paragraphs only. No bullet lists. Audience: first-scan readers. Do NOT enumerate libraries
+  or dependencies by name; you may say "Python" once or refer readers to Installation / requirements. Focus on
+  what the repo does; orient readers with capability-level surfaces (CLI, HTTP API, notebooks, training workflows)
+  supported by context—without repo paths, parenthetical filenames, or backticked file paths. Defer exact paths to
+  Getting Started.
+- core_features: at most 5 bullets. Each bullet = one distinct capability plus practical developer value in one
+  concise sentence; ground claims only in what context supports, but do NOT cite file names, paths, or
+  function/class symbols. Do NOT add bullets that only restate the dependency stack, IDE tooling, type hints,
+  "clean code", "rich libraries", persistence alone, or other generic claims.
 - getting_started: keep prerequisites short; do not paste a long package list-point to Installation or
   requirements.txt if mentioned in context.
 
@@ -526,16 +531,21 @@ Generate the **Overview** section for a README file.
 SECTION INTERNAL NAME: overview
 
 RULES:
-- Purpose: explain what the project does, who it is for, and where to start reading the code.
+- Purpose: explain what the project does, who it is for, and how newcomers orient themselves—without acting as a file index.
+- Audience: first-scan readers; where code or scripts live belongs in Getting Started, Examples, or Documentation.
 - Length: 1 short paragraph (3-5 sentences), no bullet list.
 - Include:
   1) primary project goal/problem,
   2) primary developer audience or use context,
-  3) concrete entry points from repository context (script/notebook/package paths).
+  3) orientation without file names: types of surfaces the repo offers (e.g. CLI, REST API, notebook workflows,
+     training or fine-tuning flows) only as supported by context, and/or point readers to Getting Started for
+     runnable steps.
 - Exclude:
   - feature enumeration (belongs to Core Features),
   - setup or run steps (belongs to Installation / Getting Started),
   - algorithm details (belongs to Methods and algorithms).
+- Do NOT name repository files, extensions, or paths (no backticked paths, no parenthetical filenames like (api.py)).
+- Style check: BAD: "start with cli_demo.py"; GOOD: "includes a command-line interface for interactive use."
 - Do NOT enumerate third-party libraries/dependencies by name (you may mention "Python" once).
 - Facts only - no invented paths, commands, files, claims, or performance statements.
 - Keep tone neutral and technical (no marketing language).
@@ -577,20 +587,21 @@ Generate the **Core Features** section for a README file.
 SECTION INTERNAL NAME: core_features
 
 RULES:
-- Purpose: list the project's most important capabilities for developers.
+- Purpose: list the project's most important capabilities for developers (not a map of source files).
+- Audience: first-scan readers; file-level detail belongs in Getting Started, Examples, or project layout sections.
 - Output format: 3-5 bullets only.
 - Each bullet must:
-  1) describe one distinct capability,
-  2) reference at least one concrete repository artifact (file path or function/class symbol),
-  3) state the practical developer value in one concise sentence.
+  1) describe one distinct capability supported by repository context,
+  2) state the practical developer value in one concise sentence.
+- Do NOT cite file paths, parenthetical filenames, backticked paths, or function/class symbols.
 - Order bullets by importance (most central capability first).
 - Exclude:
   - installation/run instructions,
   - repository structure mapping (belongs to Content),
   - algorithm/method explanations (belongs to Algorithms),
-  - generic quality/tooling claims without concrete evidence.
+  - generic quality/tooling claims without evidence from context.
 - Avoid overlap: do not repeat the same capability in different wording.
-- Facts only - no invented artifacts or behavior.
+- Facts only - do not invent capabilities or behavior.
 
 OUTPUT:
 Return a JSON object:

--- a/osa_tool/config/prompts/readme/system_messages.toml
+++ b/osa_tool/config/prompts/readme/system_messages.toml
@@ -108,6 +108,9 @@ Evaluate draft quality and produce actionable refinement guidance.
 Instructions:
 - Score using completeness, accuracy, clarity, structure, and user-request alignment.
 - Prioritize factual correctness over stylistic preferences.
+- If overview or core_features read like a file index (implementation filenames, backticked paths, parenthetical
+  file references), treat that as a clarity issue: recommend rerunning those sections to describe capabilities
+  without paths or symbols.
 - Report concrete, non-generic issues.
 - When scope is partial, prefer targeted section reruns over broad whole-document issues unless the problem is truly global.
 - Recommend section reruns only when section-level regeneration is clearly better than global patching.

--- a/osa_tool/config/prompts/readme/system_messages.toml
+++ b/osa_tool/config/prompts/readme/system_messages.toml
@@ -106,7 +106,9 @@ Goal:
 Evaluate draft quality and produce actionable refinement guidance.
 
 Instructions:
-- Score using completeness, accuracy, clarity, structure, and user-request alignment.
+- Use a checklist mindset (completeness, accuracy, clarity, structure, user-request alignment) but do **not**
+  output numeric quality scores; express findings only as structured issues with severities from the user prompt.
+- Do not inflate quality or declare the draft "done" while blocker or major defects remain.
 - Prioritize factual correctness over stylistic preferences.
 - If overview or core_features read like a file index (implementation filenames, backticked paths, parenthetical
   file references), treat that as a clarity issue: recommend rerunning those sections to describe capabilities

--- a/osa_tool/operations/docs/readme_generation/pipeline/graph.py
+++ b/osa_tool/operations/docs/readme_generation/pipeline/graph.py
@@ -59,13 +59,13 @@ def _build_section_regeneration_sends(state: ReadmeState) -> list[Send]:
 
 
 def _route_after_self_eval(state: ReadmeState) -> str | list[Send]:
-    if state.refinement_score is not None and state.refinement_score >= 8.0:
-        return "writer"
     if state.refinement_cycles >= state.max_refinement_cycles:
         return "writer"
     sends = _build_section_regeneration_sends(state)
     if sends:
         return sends
+    if state.refinement_effective_finish:
+        return "writer"
     if state.refinement_issues:
         return "readme_patch"
     return "writer"

--- a/osa_tool/operations/docs/readme_generation/pipeline/llm_schemas.py
+++ b/osa_tool/operations/docs/readme_generation/pipeline/llm_schemas.py
@@ -71,6 +71,7 @@ class ReadmeSelfEvalLLMOutput(BaseModel):
             else:
                 out.append(item)
         return out
+
     should_stop: bool = False
     sections_to_rerun: list[str] = Field(default_factory=list)
     section_feedback: dict[str, str] | None = None

--- a/osa_tool/operations/docs/readme_generation/pipeline/llm_schemas.py
+++ b/osa_tool/operations/docs/readme_generation/pipeline/llm_schemas.py
@@ -1,6 +1,8 @@
 """README-specific Pydantic schemas for structured LLM outputs."""
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class KeyFilesLLMOutput(BaseModel):
@@ -17,13 +19,59 @@ class SectionPlanLLMOutput(BaseModel):
     section_names: list[str] = Field(default_factory=list)
 
 
+SelfEvalSeverity = Literal["blocker", "major", "minor"]
+
+
+class SelfEvalIssue(BaseModel):
+    """One README defect from self-eval (severity + short description)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    severity: SelfEvalSeverity
+    description: str = Field(default="")
+
+    @field_validator("severity", mode="before")
+    @classmethod
+    def _normalize_severity(cls, value: object) -> object:
+        if isinstance(value, str):
+            v = value.strip().lower()
+            if v in ("blocker", "major", "minor"):
+                return v
+        return value
+
+    @field_validator("description", mode="before")
+    @classmethod
+    def _strip_description(cls, value: object) -> object:
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+
 class ReadmeSelfEvalLLMOutput(BaseModel):
     """LLM self-evaluation of a generated README."""
 
     model_config = ConfigDict(extra="ignore")
 
-    score: float = 0
-    issues: list[str] = Field(default_factory=list)
+    issues: list[SelfEvalIssue] = Field(default_factory=list)
+
+    @field_validator("issues", mode="before")
+    @classmethod
+    def _coerce_legacy_string_issues(cls, value: object) -> object:
+        """Accept pre-structured list[str] issues as major-severity items (backward compatible)."""
+        if not isinstance(value, list):
+            return value
+        out: list[object] = []
+        for item in value:
+            if isinstance(item, str):
+                text = item.strip()
+                if text:
+                    out.append({"severity": "major", "description": text})
+            else:
+                out.append(item)
+        return out
     should_stop: bool = False
     sections_to_rerun: list[str] = Field(default_factory=list)
     section_feedback: dict[str, str] | None = None
+    quality_notes: str | None = None

--- a/osa_tool/operations/docs/readme_generation/pipeline/nodes/self_eval.py
+++ b/osa_tool/operations/docs/readme_generation/pipeline/nodes/self_eval.py
@@ -1,15 +1,42 @@
-"""Self-evaluate the assembled README draft (score + issues + optional section rerun plan)."""
+"""Self-evaluate the assembled README draft (structured issues + optional section rerun plan)."""
 
 from pydantic import ValidationError
 
-from osa_tool.operations.docs.readme_generation.pipeline.runtime_context import ReadmeContext
+from osa_tool.operations.docs.readme_generation.pipeline.llm_schemas import ReadmeSelfEvalLLMOutput, SelfEvalIssue
 from osa_tool.operations.docs.readme_generation.pipeline.models import SectionSpec
+from osa_tool.operations.docs.readme_generation.pipeline.runtime_context import ReadmeContext
 from osa_tool.operations.docs.readme_generation.pipeline.state import ReadmeState
 from osa_tool.operations.docs.readme_generation.readme_utils import build_system_message
-from osa_tool.operations.docs.readme_generation.pipeline.llm_schemas import ReadmeSelfEvalLLMOutput
 from osa_tool.utils.logger import logger
 from osa_tool.utils.prompts_builder import PromptBuilder
 from osa_tool.utils.response_cleaner import JsonParseError
+
+_PARSE_FAILURE_ISSUE = SelfEvalIssue(
+    severity="major",
+    description="Self-evaluation output could not be parsed; review the README draft manually.",
+)
+_NO_ISSUE_DESCRIPTION = "(no description provided)"
+
+
+def _derived_refinement_score(issues: list[SelfEvalIssue]) -> float:
+    """Log-only heuristic from severity counts (not used for routing)."""
+    blockers = sum(1 for i in issues if i.severity == "blocker")
+    majors = sum(1 for i in issues if i.severity == "major")
+    minors = sum(1 for i in issues if i.severity == "minor")
+    return max(0.0, min(10.0, 10.0 - 3.0 * blockers - 2.0 * majors - 0.5 * minors))
+
+
+def _structured_issues_to_strings(issues: list[SelfEvalIssue]) -> list[str]:
+    lines: list[str] = []
+    for item in issues:
+        desc = (item.description or "").strip()
+        if not desc:
+            if item.severity in ("blocker", "major"):
+                desc = _NO_ISSUE_DESCRIPTION
+            else:
+                continue
+        lines.append(f"({item.severity}) {desc}")
+    return lines
 
 
 def _filter_sections_to_rerun(names: list[str], section_plan: list[SectionSpec]) -> list[str]:
@@ -24,8 +51,27 @@ def _filter_sections_to_rerun(names: list[str], section_plan: list[SectionSpec])
     return kept
 
 
+def _compute_effective_finish(
+    should_stop: bool,
+    structured: list[SelfEvalIssue],
+    sections_to_rerun: list[str],
+) -> bool:
+    has_blocker_or_major = any(i.severity in ("blocker", "major") for i in structured)
+    if should_stop and has_blocker_or_major:
+        logger.warning(
+            "[SelfEval] Model set should_stop despite blocker/major issues; continuing refinement.",
+        )
+    if should_stop and sections_to_rerun:
+        logger.warning(
+            "[SelfEval] Model set should_stop but sections_to_rerun is non-empty; regenerating sections first.",
+        )
+    return bool(
+        should_stop and not has_blocker_or_major and not sections_to_rerun,
+    )
+
+
 def self_eval_node(state: ReadmeState, ctx: ReadmeContext) -> dict:
-    """Score the current readme_draft and optionally request LLM section regeneration."""
+    """Evaluate readme_draft and optionally request LLM section regeneration or patching."""
     cycle = state.refinement_cycles + 1
     logger.info("[SelfEval] Evaluation cycle %d...", cycle)
 
@@ -57,35 +103,46 @@ def self_eval_node(state: ReadmeState, ctx: ReadmeContext) -> dict:
             parser=ReadmeSelfEvalLLMOutput,
             system_message=build_system_message(ctx, "self_eval"),
         )
-        refinement_score = float(eval_result.score)
-        refinement_issues = list(eval_result.issues)
+        structured = list(eval_result.issues)
+        refinement_issues = _structured_issues_to_strings(structured)
         sections_to_rerun = _filter_sections_to_rerun(
             [x.strip() for x in eval_result.sections_to_rerun if x and str(x).strip()],
             state.section_plan,
         )
         hints_raw = eval_result.section_feedback if eval_result.section_feedback else {}
         section_regeneration_hints = {str(k).strip(): str(v).strip() for k, v in hints_raw.items() if k}
-        if eval_result.should_stop:
-            refinement_score = max(refinement_score, 8.0)
+        refinement_effective_finish = _compute_effective_finish(
+            eval_result.should_stop,
+            structured,
+            sections_to_rerun,
+        )
+        refinement_score = _derived_refinement_score(structured)
+        if eval_result.quality_notes:
+            logger.debug("[SelfEval] quality_notes=%s", eval_result.quality_notes)
         logger.info(
-            "[SelfEval] Cycle %d: score=%.1f, issues=%d, should_stop=%s, rerun=%s",
+            "[SelfEval] Cycle %d: derived_score=%.1f, issues=%d, effective_finish=%s, should_stop=%s, rerun=%s",
             cycle,
             refinement_score,
-            len(refinement_issues),
+            len(structured),
+            refinement_effective_finish,
             eval_result.should_stop,
             sections_to_rerun,
         )
     except (JsonParseError, ValidationError) as exc:
-        refinement_score = 7.0
-        refinement_issues = []
+        structured = [_PARSE_FAILURE_ISSUE]
+        refinement_issues = _structured_issues_to_strings(structured)
         sections_to_rerun = []
         section_regeneration_hints = {}
-        logger.warning("[SelfEval] Parse failed (%s); defaulting score=7.0", exc)
+        refinement_effective_finish = False
+        refinement_score = _derived_refinement_score(structured)
+        logger.warning("[SelfEval] Parse failed (%s); using fallback major issue.", exc)
 
     logger.debug("[SelfEval] State after node: %s", state)
     return {
         "refinement_cycles": cycle,
         "refinement_score": refinement_score,
+        "refinement_structured_issues": [i.model_dump() for i in structured],
+        "refinement_effective_finish": refinement_effective_finish,
         "refinement_issues": refinement_issues,
         "sections_to_rerun": sections_to_rerun,
         "section_regeneration_hints": section_regeneration_hints,

--- a/osa_tool/operations/docs/readme_generation/pipeline/state.py
+++ b/osa_tool/operations/docs/readme_generation/pipeline/state.py
@@ -5,6 +5,7 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from osa_tool.core.models.event import OperationEvent
+from osa_tool.operations.docs.readme_generation.pipeline.llm_schemas import SelfEvalIssue
 from osa_tool.operations.docs.readme_generation.pipeline.models import (
     RepositoryContext,
     SectionResult,
@@ -51,6 +52,8 @@ class ReadmeState(BaseModel):
     # Assembly & self-eval refinement
     readme_draft: str | None = None
     refinement_score: float | None = None
+    refinement_structured_issues: list[SelfEvalIssue] = Field(default_factory=list)
+    refinement_effective_finish: bool = False
     refinement_issues: list[str] = Field(default_factory=list)
     refinement_cycles: int = 0
     max_refinement_cycles: int = 3
@@ -92,6 +95,8 @@ class ReadmeState(BaseModel):
             f"  readme_draft={'%d chars' % len(self.readme_draft) if self.readme_draft else None},\n"
             f"  refinement_cycles={self.refinement_cycles}/{self.max_refinement_cycles},\n"
             f"  refinement_score={self.refinement_score},\n"
+            f"  refinement_effective_finish={self.refinement_effective_finish},\n"
+            f"  refinement_structured_issues={len(self.refinement_structured_issues)},\n"
             f"  sections_to_rerun={self.sections_to_rerun},\n"
             f"  events={len(self.events)},\n"
             f")"

--- a/osa_tool/run_multi_process.py
+++ b/osa_tool/run_multi_process.py
@@ -39,7 +39,13 @@ async def generate_readme(config_manager: ConfigManager, metadata: RepositoryMet
     readmes_dir = os.path.join(os.path.dirname(args.table_path), "readmes")
     os.makedirs(readmes_dir, exist_ok=True)
 
-    readme_agent = ReadmeAgent(config_manager, metadata, None, "Generate or upgrade README")
+    readme_agent = ReadmeAgent(
+        config_manager,
+        metadata,
+        None,
+        "Evaluate the existing README for quality: if it’s missing, generate one;"
+        " if it’s poor, rewrite it completely; if it’s good, identify and apply targeted improvements."
+    )
     dest_path = os.path.join(readmes_dir, f"{metadata.name}_README.md")
     readme_agent.file_to_save = dest_path
 

--- a/osa_tool/run_multi_process.py
+++ b/osa_tool/run_multi_process.py
@@ -44,7 +44,7 @@ async def generate_readme(config_manager: ConfigManager, metadata: RepositoryMet
         metadata,
         None,
         "Evaluate the existing README for quality: if it’s missing, generate one;"
-        " if it’s poor, rewrite it completely; if it’s good, identify and apply targeted improvements."
+        " if it’s poor, rewrite it completely; if it’s good, identify and apply targeted improvements.",
     )
     dest_path = os.path.join(readmes_dir, f"{metadata.name}_README.md")
     readme_agent.file_to_save = dest_path

--- a/tests/unit/operations/docs/readme_generation/pipeline/nodes/test_self_eval.py
+++ b/tests/unit/operations/docs/readme_generation/pipeline/nodes/test_self_eval.py
@@ -1,5 +1,11 @@
+from osa_tool.operations.docs.readme_generation.pipeline.llm_schemas import ReadmeSelfEvalLLMOutput, SelfEvalIssue
 from osa_tool.operations.docs.readme_generation.pipeline.models import SectionSpec
-from osa_tool.operations.docs.readme_generation.pipeline.nodes.self_eval import _filter_sections_to_rerun
+from osa_tool.operations.docs.readme_generation.pipeline.nodes.self_eval import (
+    _compute_effective_finish,
+    _derived_refinement_score,
+    _filter_sections_to_rerun,
+    _structured_issues_to_strings,
+)
 
 
 def test_filter_sections_to_rerun_keeps_only_planned_llm_sections() -> None:
@@ -15,3 +21,61 @@ def test_filter_sections_to_rerun_keeps_only_planned_llm_sections() -> None:
 
     # Assert
     assert filtered == ["overview"]
+
+
+def test_structured_issues_to_strings_formats_and_skips_empty() -> None:
+    issues = [
+        SelfEvalIssue(severity="blocker", description="wrong repo name"),
+        SelfEvalIssue(severity="minor", description=""),
+    ]
+    assert _structured_issues_to_strings(issues) == ["(blocker) wrong repo name"]
+
+
+def test_structured_issues_to_strings_placeholder_for_empty_blocker_or_major() -> None:
+    issues = [
+        SelfEvalIssue(severity="major", description=""),
+        SelfEvalIssue(severity="blocker", description="   "),
+    ]
+    out = _structured_issues_to_strings(issues)
+    assert out == [
+        "(major) (no description provided)",
+        "(blocker) (no description provided)",
+    ]
+
+
+def test_derived_refinement_score_reflects_severities() -> None:
+    empty: list[SelfEvalIssue] = []
+    assert _derived_refinement_score(empty) == 10.0
+    one_major = [SelfEvalIssue(severity="major", description="x")]
+    assert _derived_refinement_score(one_major) == 8.0
+    one_blocker = [SelfEvalIssue(severity="blocker", description="x")]
+    assert _derived_refinement_score(one_blocker) == 7.0
+
+
+def test_effective_finish_requires_stop_without_blocker_major_or_rerun() -> None:
+    assert _compute_effective_finish(
+        True,
+        [SelfEvalIssue(severity="minor", description="typo")],
+        [],
+    )
+    assert not _compute_effective_finish(
+        True,
+        [SelfEvalIssue(severity="major", description="gap")],
+        [],
+    )
+    assert not _compute_effective_finish(True, [], ["overview"])
+    assert not _compute_effective_finish(False, [], [])
+
+
+def test_readme_self_eval_coerces_legacy_string_issues() -> None:
+    parsed = ReadmeSelfEvalLLMOutput.model_validate(
+        {
+            "issues": ["legacy issue one", "  ", "legacy two"],
+            "should_stop": False,
+            "score": 7,
+        }
+    )
+    assert len(parsed.issues) == 2
+    assert parsed.issues[0].severity == "major"
+    assert parsed.issues[0].description == "legacy issue one"
+    assert parsed.issues[1].description == "legacy two"

--- a/tests/unit/operations/docs/readme_generation/pipeline/test_readme_graph_routing.py
+++ b/tests/unit/operations/docs/readme_generation/pipeline/test_readme_graph_routing.py
@@ -1,0 +1,76 @@
+"""Routing after self_eval (section regen vs patch vs writer)."""
+
+from langgraph.types import Send
+
+from osa_tool.operations.docs.readme_generation.pipeline.graph import _route_after_self_eval
+from osa_tool.operations.docs.readme_generation.pipeline.models import SectionSpec
+from osa_tool.operations.docs.readme_generation.pipeline.state import ReadmeState
+
+
+def _minimal_state(**kwargs: object) -> ReadmeState:
+    base = {
+        "repo_url": "https://example.com/repo",
+        "refinement_cycles": 1,
+        "max_refinement_cycles": 3,
+        "refinement_effective_finish": False,
+        "refinement_issues": [],
+        "sections_to_rerun": [],
+        "section_plan": [],
+    }
+    base.update(kwargs)
+    return ReadmeState.model_validate(base)
+
+
+def test_route_max_cycles_sends_writer_even_with_pending_rerun() -> None:
+    plan = [SectionSpec(name="overview", title="Overview", strategy="llm")]
+    state = _minimal_state(
+        refinement_cycles=3,
+        max_refinement_cycles=3,
+        sections_to_rerun=["overview"],
+        section_plan=plan,
+        refinement_effective_finish=False,
+        refinement_issues=["(major) still broken"],
+    )
+    assert _route_after_self_eval(state) == "writer"
+
+
+def test_route_section_regeneration_before_effective_finish() -> None:
+    plan = [SectionSpec(name="overview", title="Overview", strategy="llm")]
+    state = _minimal_state(
+        refinement_cycles=1,
+        sections_to_rerun=["overview"],
+        section_plan=plan,
+        refinement_effective_finish=True,
+        refinement_issues=["(major) should not skip regen"],
+    )
+    out = _route_after_self_eval(state)
+    assert isinstance(out, list)
+    assert len(out) == 1
+    assert isinstance(out[0], Send)
+
+
+def test_route_effective_finish_to_writer() -> None:
+    state = _minimal_state(
+        refinement_effective_finish=True,
+        refinement_issues=[],
+        sections_to_rerun=[],
+    )
+    assert _route_after_self_eval(state) == "writer"
+
+
+def test_route_issues_to_readme_patch() -> None:
+    state = _minimal_state(
+        refinement_effective_finish=False,
+        refinement_issues=["(major) fix contradiction"],
+        sections_to_rerun=[],
+    )
+    assert _route_after_self_eval(state) == "readme_patch"
+
+
+def test_route_no_work_to_writer() -> None:
+    state = _minimal_state(
+        refinement_effective_finish=False,
+        refinement_issues=[],
+        sections_to_rerun=[],
+    )
+    assert _route_after_self_eval(state) == "writer"


### PR DESCRIPTION
Поправил промпты для генерации секций core_features и overview
Поправил оценку драфта README

UPD:
Есть еще не опубликованная ветка с таким же названием под номером два. Там намного больше изменений, в частности улучшения связанные с поиском key_files + две новых ноды (Оценка оригинального README и его анализ + Принятие решение об улучшении README) + много более мелких изменений. 
В такой конфигурации смог выбить метрику 0.96 на gpt-4.1. Однако если смотреть на получившиеся README, то почти во всех изменения были минимальны, так как изначально README в тех репозиториях очень высокого качества.