### PR TITLE
Bug fixes: SelfEval loop & LLM control characters

### DIFF
--- a/osa_tool/operations/docs/readme_generation/pipeline/nodes/self_eval.py
+++ b/osa_tool/operations/docs/readme_generation/pipeline/nodes/self_eval.py
@@ -55,6 +55,7 @@ def _compute_effective_finish(
     should_stop: bool,
     structured: list[SelfEvalIssue],
     sections_to_rerun: list[str],
+    all_reruns_dropped: bool = False,
 ) -> bool:
     has_blocker_or_major = any(i.severity in ("blocker", "major") for i in structured)
     if should_stop and has_blocker_or_major:
@@ -65,6 +66,12 @@ def _compute_effective_finish(
         logger.warning(
             "[SelfEval] Model set should_stop but sections_to_rerun is non-empty; regenerating sections first.",
         )
+    if all_reruns_dropped and not has_blocker_or_major:
+        logger.warning(
+            "[SelfEval] All requested sections_to_rerun are non-LLM (deterministic/keep_existing); "
+            "nothing actionable remains — treating as effective finish.",
+        )
+        return True
     return bool(
         should_stop and not has_blocker_or_major and not sections_to_rerun,
     )
@@ -105,16 +112,16 @@ def self_eval_node(state: ReadmeState, ctx: ReadmeContext) -> dict:
         )
         structured = list(eval_result.issues)
         refinement_issues = _structured_issues_to_strings(structured)
-        sections_to_rerun = _filter_sections_to_rerun(
-            [x.strip() for x in eval_result.sections_to_rerun if x and str(x).strip()],
-            state.section_plan,
-        )
+        requested_sections = [x.strip() for x in eval_result.sections_to_rerun if x and str(x).strip()]
+        sections_to_rerun = _filter_sections_to_rerun(requested_sections, state.section_plan)
+        all_reruns_dropped = bool(requested_sections) and not sections_to_rerun
         hints_raw = eval_result.section_feedback if eval_result.section_feedback else {}
         section_regeneration_hints = {str(k).strip(): str(v).strip() for k, v in hints_raw.items() if k}
         refinement_effective_finish = _compute_effective_finish(
             eval_result.should_stop,
             structured,
             sections_to_rerun,
+            all_reruns_dropped=all_reruns_dropped,
         )
         refinement_score = _derived_refinement_score(structured)
         if eval_result.quality_notes:

--- a/osa_tool/utils/response_cleaner.py
+++ b/osa_tool/utils/response_cleaner.py
@@ -20,6 +20,10 @@ class JsonProcessor:
         if not isinstance(text, str):
             raise ValueError("Input must be a string.")
 
+        # Strip raw control characters that are invalid in JSON string values.
+        # Preserves \t (0x09), \n (0x0A), \r (0x0D) which JSON parsers accept unescaped.
+        text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", text)
+
         replacements = {"None": "null", "True": "true", "False": "false"}
         for key, value in replacements.items():
             text = text.replace(key, value)


### PR DESCRIPTION
`osa_tool/utils/response_cleaner.py`
Исправлены периодические ошибки парсинга JSON, вызванные сырыми управляющими символами в ответах LLM. В начало JsonProcessor.process_text добавлен re.sub, который удаляет символы, недопустимые в JSON-строках, сохраняя \t, \n, \r. Фикс покрывает все пути парсинга, так как и send_and_parse, и JsonProcessor.parse проходят через этот метод.

`osa_tool/operations/docs/readme_generation/pipeline/nodes/self_eval.py`
Исправлено зависание цикла рефайнмента в ситуации, когда SelfEval запрашивал перегенерацию deterministic/keep_existing секций README (например, installation, license, citation). Такие секции корректно отфильтровывались в _filter_sections_to_rerun, однако пустой sections_to_rerun при should_stop=False давал effective_finish=False - цикл повторялся до max_refinement_cycles без каких-либо изменений в выводе или оценке.

Добавлен флаг all_reruns_dropped: если все запрошенные LLM секции отброшены фильтром и среди выявленных проблем нет blocker/major, _compute_effective_finish теперь немедленно возвращает True. Если среди запрошенных есть валидные LLM-секции или присутствуют серьёзные проблемы - поведение не изменилось.