### PR TITLE
test: add integration test for readme self-correction routing

### DIFF
--- a/tests/integration/test_readme_iterations.py
+++ b/tests/integration/test_readme_iterations.py
@@ -1,0 +1,87 @@
+"""Integration tests for the README generation pipeline's iterative self-correction loop."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from osa_tool.operations.docs.readme_generation.pipeline.state import ReadmeState
+from osa_tool.operations.docs.readme_generation.pipeline.graph import build_readme_graph
+from osa_tool.operations.docs.readme_generation.pipeline.llm_schemas import ReadmeSelfEvalLLMOutput, SelfEvalIssue
+from osa_tool.operations.docs.readme_generation.pipeline.models import SectionSpec
+
+
+@pytest.mark.asyncio
+@patch("osa_tool.operations.docs.readme_generation.pipeline.graph.writer_node", return_value={})
+@patch("osa_tool.operations.docs.readme_generation.pipeline.graph.readme_patch_node", return_value={})
+@patch("osa_tool.operations.docs.readme_generation.pipeline.graph.assembler_node", return_value={})
+@patch("osa_tool.operations.docs.readme_generation.pipeline.graph.section_generator_node", return_value={})
+@patch("osa_tool.operations.docs.readme_generation.pipeline.graph.section_planner_node", return_value={})
+@patch("osa_tool.operations.docs.readme_generation.pipeline.graph.intent_analyzer_node", return_value={})
+@patch("osa_tool.operations.docs.readme_generation.pipeline.graph.context_collector_node", return_value={})
+async def test_readme_self_correction_loop(
+        mock_context, mock_intent, mock_planner, mock_generator,
+        mock_assembler, mock_patch, mock_writer
+):
+    """
+    Tests the self-evaluation and refinement cycle of the README generation graph.
+    All nodes except `self_eval_node` are mocked to isolate the routing logic.
+    """
+    state = ReadmeState(
+        repo_url="https://github.com/fake/repo",
+        user_request="Make a good readme",
+        max_refinement_cycles=3,
+        section_plan=[SectionSpec(name="Overview", title="Overview", strategy="llm", tools=[])]
+    )
+
+    ctx = MagicMock()
+    ctx.model_handler = MagicMock()
+    ctx.prompts = MagicMock()
+    ctx.prompts.get.return_value = "fake_prompt"
+
+    def mock_send_and_parse(*args, **kwargs):
+        parser = kwargs.get('parser')
+
+        if parser == ReadmeSelfEvalLLMOutput:
+            mock_send_and_parse.eval_call_count = getattr(mock_send_and_parse, 'eval_call_count', 0) + 1
+
+            if mock_send_and_parse.eval_call_count == 1:
+                # ИТЕРАЦИЯ 1: Комплексный провал по нескольким параметрам
+                return ReadmeSelfEvalLLMOutput(
+                    should_stop=False,
+                    issues=[
+                        SelfEvalIssue(
+                            severity="blocker",
+                            description="CRITICAL: Missing installation and setup instructions."
+                        ),
+                        SelfEvalIssue(
+                            severity="warning",
+                            description="FORMATTING: Inconsistent Markdown headers and missing code blocks."
+                        ),
+                    ],
+
+                    sections_to_rerun=["Overview"],
+                    section_feedback={
+                        "Overview": "Rewrite to include setup steps, fix Markdown formatting, and enforce strictly English."
+                    },
+                    quality_notes="Failed multiple quality checks: missing dependencies info, bad formatting, wrong language."
+                )
+            else:
+
+                return ReadmeSelfEvalLLMOutput(
+                    should_stop=True,
+                    issues=[],
+                    sections_to_rerun=[],
+                    section_feedback={},
+                    quality_notes="Passed all quality metrics: structure, formatting, and language are perfect."
+                )
+        return MagicMock()
+
+    ctx.model_handler.send_and_parse.side_effect = mock_send_and_parse
+
+    graph = build_readme_graph(ctx)
+    final_state_raw = await graph.ainvoke(state.model_dump())
+    final_state = ReadmeState.model_validate(final_state_raw)
+
+    assert final_state.refinement_cycles == 2, f"Expected 2 cycles, got {final_state.refinement_cycles}"
+    assert final_state.refinement_effective_finish is True, "Graph finished with unresolved errors"
+    assert len(
+        final_state.refinement_structured_issues) == 0, "Issues list should be empty on final successful iteration"

--- a/tests/integration/test_readme_iterations.py
+++ b/tests/integration/test_readme_iterations.py
@@ -18,8 +18,7 @@ from osa_tool.operations.docs.readme_generation.pipeline.models import SectionSp
 @patch("osa_tool.operations.docs.readme_generation.pipeline.graph.intent_analyzer_node", return_value={})
 @patch("osa_tool.operations.docs.readme_generation.pipeline.graph.context_collector_node", return_value={})
 async def test_readme_self_correction_loop(
-        mock_context, mock_intent, mock_planner, mock_generator,
-        mock_assembler, mock_patch, mock_writer
+    mock_context, mock_intent, mock_planner, mock_generator, mock_assembler, mock_patch, mock_writer
 ):
     """
     Tests the self-evaluation and refinement cycle of the README generation graph.
@@ -29,7 +28,7 @@ async def test_readme_self_correction_loop(
         repo_url="https://github.com/fake/repo",
         user_request="Make a good readme",
         max_refinement_cycles=3,
-        section_plan=[SectionSpec(name="Overview", title="Overview", strategy="llm", tools=[])]
+        section_plan=[SectionSpec(name="Overview", title="Overview", strategy="llm", tools=[])],
     )
 
     ctx = MagicMock()
@@ -38,10 +37,10 @@ async def test_readme_self_correction_loop(
     ctx.prompts.get.return_value = "fake_prompt"
 
     def mock_send_and_parse(*args, **kwargs):
-        parser = kwargs.get('parser')
+        parser = kwargs.get("parser")
 
         if parser == ReadmeSelfEvalLLMOutput:
-            mock_send_and_parse.eval_call_count = getattr(mock_send_and_parse, 'eval_call_count', 0) + 1
+            mock_send_and_parse.eval_call_count = getattr(mock_send_and_parse, "eval_call_count", 0) + 1
 
             if mock_send_and_parse.eval_call_count == 1:
                 # ИТЕРАЦИЯ 1: Комплексный провал по нескольким параметрам
@@ -49,20 +48,18 @@ async def test_readme_self_correction_loop(
                     should_stop=False,
                     issues=[
                         SelfEvalIssue(
-                            severity="blocker",
-                            description="CRITICAL: Missing installation and setup instructions."
+                            severity="blocker", description="CRITICAL: Missing installation and setup instructions."
                         ),
                         SelfEvalIssue(
                             severity="warning",
-                            description="FORMATTING: Inconsistent Markdown headers and missing code blocks."
+                            description="FORMATTING: Inconsistent Markdown headers and missing code blocks.",
                         ),
                     ],
-
                     sections_to_rerun=["Overview"],
                     section_feedback={
                         "Overview": "Rewrite to include setup steps, fix Markdown formatting, and enforce strictly English."
                     },
-                    quality_notes="Failed multiple quality checks: missing dependencies info, bad formatting, wrong language."
+                    quality_notes="Failed multiple quality checks: missing dependencies info, bad formatting, wrong language.",
                 )
             else:
 
@@ -71,7 +68,7 @@ async def test_readme_self_correction_loop(
                     issues=[],
                     sections_to_rerun=[],
                     section_feedback={},
-                    quality_notes="Passed all quality metrics: structure, formatting, and language are perfect."
+                    quality_notes="Passed all quality metrics: structure, formatting, and language are perfect.",
                 )
         return MagicMock()
 
@@ -83,5 +80,6 @@ async def test_readme_self_correction_loop(
 
     assert final_state.refinement_cycles == 2, f"Expected 2 cycles, got {final_state.refinement_cycles}"
     assert final_state.refinement_effective_finish is True, "Graph finished with unresolved errors"
-    assert len(
-        final_state.refinement_structured_issues) == 0, "Issues list should be empty on final successful iteration"
+    assert (
+        len(final_state.refinement_structured_issues) == 0
+    ), "Issues list should be empty on final successful iteration"


### PR DESCRIPTION
Adds an isolated integration test to verify the LangGraph routing logic for the README pipeline's iterative self-correction 

Implementation Details
* Node Isolation: Mocks all operational nodes (e.g., `section_generator`, `assembler`, `writer`) using `@patch` to test strictly the routing mechanism.
* 
* LLM Simulation: Replaces the real LLM call with a `mock_send_and_parse` function that simulates a multi-issue scenario:
* Iteration 1: Returns a blocker (missing installation), warnings (bad formatting, etc), and triggers a rewrite for the `Overview` section (`should_stop=False`)
* Iteration 2: Returns a clean state (`should_stop=True`).
* Assertions: Validates that `refinement_cycles` increments to exactly 2, and the graph finishes effectively without unresolved issues.

