### PR TITLE
fix/Fix error executor agent

### DIFF
--- a/osa_tool/osa_agent/agents/executor/agent.py
+++ b/osa_tool/osa_agent/agents/executor/agent.py
@@ -4,6 +4,7 @@ from rich import box
 from rich.table import Table
 
 from osa_tool.core.models.agent_status import AgentStatus
+from osa_tool.core.models.event import EventKind, OperationEvent
 from osa_tool.core.models.task import TaskStatus, Task
 from osa_tool.operations.registry import OperationRegistry
 from osa_tool.osa_agent.base import BaseAgent
@@ -25,6 +26,21 @@ class ExecutorAgent(BaseAgent):
     """
 
     name = "Executor"
+
+    _SUCCESS_EVENT_KINDS = frozenset(
+        {
+            EventKind.ANALYZED,
+            EventKind.CREATED,
+            EventKind.GENERATED,
+            EventKind.SET,
+            EventKind.REFINED,
+            EventKind.UPDATED,
+            EventKind.MOVED,
+            EventKind.WRITTEN,
+            EventKind.EXISTS,
+            EventKind.UPLOADED,
+        }
+    )
 
     def run(self, state: OSAState) -> OSAState:
         """
@@ -83,8 +99,13 @@ class ExecutorAgent(BaseAgent):
             result = self._execute_task(task, state)
             task.result = result.get("result")
             task.events = result.get("events", [])
-            task.status = TaskStatus.COMPLETED
-            logger.info("Task '%s' completed", task.id)
+
+            if self._is_failure_result(result):
+                task.status = TaskStatus.FAILED
+                logger.error("Task '%s' failed (reported by operation result)", task.id)
+            else:
+                task.status = TaskStatus.COMPLETED
+                logger.info("Task '%s' completed", task.id)
 
         except Exception as e:
             task.status = TaskStatus.FAILED
@@ -153,6 +174,35 @@ class ExecutorAgent(BaseAgent):
             raise TypeError(f"Invalid executor type for task '{task.id}': {type(executor)}")
 
         return self._normalize_result(result)
+
+    @classmethod
+    def _is_failure_result(cls, normalized: dict[str, Any]) -> bool:
+        """
+        Detect operation-level failure from a normalized executor result.
+
+        Operations typically return ``{"result": ..., "events": [...]}`` instead of
+        raising exceptions. Failures are indicated by an ``error`` key in the result
+        payload and/or ``EventKind.FAILED`` events without any successful outcome.
+        Partial failures (some targets failed, others succeeded) are not treated as
+        task failures.
+        """
+        payload = normalized.get("result")
+        if isinstance(payload, dict) and "error" in payload:
+            return True
+
+        events = normalized.get("events") or []
+        has_failed = any(cls._event_kind(event) == EventKind.FAILED for event in events)
+        if not has_failed:
+            return False
+
+        has_success = any(cls._event_kind(event) in cls._SUCCESS_EVENT_KINDS for event in events)
+        return not has_success
+
+    @staticmethod
+    def _event_kind(event: OperationEvent | dict) -> EventKind:
+        if isinstance(event, OperationEvent):
+            return event.kind
+        return EventKind(event["kind"])
 
     @staticmethod
     def _normalize_result(result) -> dict:

--- a/tests/unit/osa_agent/test_executor_agent.py
+++ b/tests/unit/osa_agent/test_executor_agent.py
@@ -1,0 +1,147 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from osa_tool.core.models.event import EventKind, OperationEvent
+from osa_tool.core.models.task import Task, TaskStatus
+from osa_tool.operations.registry import Operation, OperationRegistry
+from osa_tool.osa_agent.agents.executor.agent import ExecutorAgent
+from osa_tool.osa_agent.state import OSAState
+
+
+class _TestOperation(Operation):
+    name = "executor_test_op"
+    description = "test"
+    supported_intents = ["new_task"]
+    supported_scopes = ["full_repo"]
+    executor = None
+
+
+@pytest.fixture
+def isolated_registry():
+    saved = OperationRegistry._operations.copy()
+    OperationRegistry._operations.clear()
+    yield
+    OperationRegistry._operations.clear()
+    OperationRegistry._operations.update(saved)
+
+
+@pytest.fixture
+def executor():
+    return ExecutorAgent(context=MagicMock())
+
+
+@pytest.mark.parametrize(
+    ("normalized", "expected"),
+    [
+        ({"result": {"error": "boom"}, "events": []}, True),
+        (
+            {
+                "result": None,
+                "events": [OperationEvent(kind=EventKind.FAILED, target="README.md")],
+            },
+            True,
+        ),
+        (
+            {
+                "result": {"file": "README.md"},
+                "events": [OperationEvent(kind=EventKind.GENERATED, target="README.md")],
+            },
+            False,
+        ),
+        (
+            {
+                "result": {"generated": False},
+                "events": [OperationEvent(kind=EventKind.SKIPPED, target="workflows")],
+            },
+            False,
+        ),
+        (
+            {
+                "result": {"generated": False},
+                "events": [OperationEvent(kind=EventKind.FAILED, target="workflows")],
+            },
+            True,
+        ),
+        (
+            {
+                "result": {"path": "requirements.txt"},
+                "events": [
+                    OperationEvent(kind=EventKind.FAILED, target="requirements.txt", data={"mode": "scan-notebooks"}),
+                    OperationEvent(kind=EventKind.GENERATED, target="requirements.txt", data={"mode": "no-notebooks"}),
+                ],
+            },
+            False,
+        ),
+        (
+            {
+                "result": {"generated": ["CONTRIBUTING.md"]},
+                "events": [
+                    OperationEvent(kind=EventKind.FAILED, target="SECURITY"),
+                    OperationEvent(kind=EventKind.GENERATED, target="CONTRIBUTING"),
+                ],
+            },
+            False,
+        ),
+    ],
+)
+def test_is_failure_result(executor, normalized, expected):
+    assert executor._is_failure_result(normalized) is expected
+
+
+def test_run_task_marks_failed_when_operation_reports_failure(isolated_registry, executor):
+    def failing_executor():
+        return {
+            "result": None,
+            "events": [OperationEvent(kind=EventKind.FAILED, target="README.md", data={"error": "timeout"})],
+        }
+
+    op = _TestOperation()
+    op.executor = failing_executor
+    OperationRegistry.register(op)
+
+    task = Task(id="executor_test_op", description="test")
+    state = OSAState(session_id="s1")
+
+    executor._run_task(task, state)
+
+    assert task.status is TaskStatus.FAILED
+    assert task.result is None
+    assert len(task.events) == 1
+
+
+def test_run_task_marks_completed_on_success(isolated_registry, executor):
+    def successful_executor():
+        return {
+            "result": {"file": "README.md"},
+            "events": [OperationEvent(kind=EventKind.GENERATED, target="README.md")],
+        }
+
+    op = _TestOperation()
+    op.executor = successful_executor
+    OperationRegistry.register(op)
+
+    task = Task(id="executor_test_op", description="test")
+    state = OSAState(session_id="s1")
+
+    executor._run_task(task, state)
+
+    assert task.status is TaskStatus.COMPLETED
+    assert task.result == {"file": "README.md"}
+
+
+def test_run_task_marks_failed_on_exception(isolated_registry, executor):
+    def raising_executor():
+        raise RuntimeError("unexpected crash")
+
+    op = _TestOperation()
+    op.executor = raising_executor
+    OperationRegistry.register(op)
+
+    task = Task(id="executor_test_op", description="test")
+    state = OSAState(session_id="s1")
+
+    executor._run_task(task, state)
+
+    assert task.status is TaskStatus.FAILED
+    assert task.result == {"error": "unexpected crash"}


### PR DESCRIPTION
Добавил поиск ошибки из результата операций только для run_chat пайплайна, чтобы рефакторинг был не такой большой и меньше было MR конфликтов