### PR TITLE
fix: resolve claim extraction P1 and P2 review findings

### DIFF
--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -467,14 +467,12 @@ class GitAgent(abc.ABC):
             return True
         except GitCommandError as e:
             self._handle_git_error(e, f"pushing to {branch}")
-            logger.error(
-                f"""Push failed: Branch '{branch}' already exists in the fork.
+            logger.error(f"""Push failed: Branch '{branch}' already exists in the fork.
                  To resolve this, please either:
                    1. Choose a different branch name that doesn't exist in the fork
                       by modifying the `branch_name` parameter.
                    2. Delete the existing branch from forked repository.
-                   3. Delete the fork entirely."""
-            )
+                   3. Delete the fork entirely.""")
             return False
 
     def upload_report(

--- a/osa_tool/operations/analysis/paper_claims/claim_extractor.py
+++ b/osa_tool/operations/analysis/paper_claims/claim_extractor.py
@@ -6,8 +6,13 @@ from typing import Any, Callable, Protocol
 from pydantic import TypeAdapter, ValidationError
 from rich.progress import track
 
-from osa_tool.operations.analysis.paper_claims.claim_schemas import ClaimCandidateResponse, SelectedSectionResponse
-from osa_tool.operations.analysis.paper_claims.claim_validation import partition_valid_claim_candidates
+from osa_tool.operations.analysis.paper_claims.claim_schemas import (
+    ClaimCandidateResponse,
+    SelectedSectionResponse,
+)
+from osa_tool.operations.analysis.paper_claims.claim_validation import (
+    partition_valid_claim_candidates,
+)
 from osa_tool.operations.analysis.paper_claims.exceptions import ClaimExtractionError
 from osa_tool.operations.analysis.paper_claims.models import (
     ClaimExtractionResult,
@@ -19,10 +24,13 @@ from osa_tool.operations.analysis.paper_claims.models import (
 from osa_tool.utils.logger import logger
 from osa_tool.utils.prompts_builder import PromptBuilder, PromptLoader
 from osa_tool.utils.response_cleaner import JsonParseError, JsonProcessor
+from osa_tool.utils.token_counter import count_tokens
 
 
 class AsyncModelHandler(Protocol):
-    async def async_request(self, prompt: str, system_message: str | None = None, retry_delay: float = 1) -> str: ...
+    async def async_request(
+        self, prompt: str, system_message: str | None = None, retry_delay: float = 1
+    ) -> str: ...
 
 
 class ClaimExtractor:
@@ -43,6 +51,61 @@ class ClaimExtractor:
         self.max_retries = max_retries
         self.dedup_batch_size = dedup_batch_size
 
+    def _section_chunks(self, section: PaperSection, system: str) -> list[PaperSection]:
+        """Split a section to fit the handler input budget with a small overlap."""
+        settings = getattr(self.handler, "model_settings", None)
+        if (
+            settings is None
+            or not hasattr(settings, "context_window")
+            or not hasattr(settings, "max_tokens")
+        ):
+            return [section]
+        encoder = getattr(settings, "encoder", "cl100k_base")
+        total_input_budget = (
+            getattr(settings, "context_window", 0)
+            - getattr(settings, "max_tokens", 0)
+            - 256
+        )
+        # A character is never less conservative than a token for ordinary
+        # text; avoid loading an encoder at all for obviously short sections.
+        if len(system) + len(section.text) <= total_input_budget:
+            return [section]
+        try:
+            system_tokens = count_tokens(system, encoder)
+        except Exception as exc:
+            logger.warning(
+                "Token encoder unavailable; using conservative character-based section chunks: %s",
+                exc,
+            )
+            system_tokens = len(system)
+            budget = total_input_budget - system_tokens
+            if budget <= 0 or len(section.text) <= budget:
+                return [section]
+            overlap = min(128, max(1, budget // 10))
+            step = max(1, budget - overlap)
+            return [
+                section.model_copy(
+                    update={"text": section.text[start : start + budget]}
+                )
+                for start in range(0, len(section.text), step)
+            ]
+
+        budget = total_input_budget - system_tokens
+        if budget <= 0 or count_tokens(section.text, encoder) <= budget:
+            return [section]
+        from osa_tool.utils.token_counter import _get_encoder
+
+        codec = _get_encoder(encoder)
+        tokens = codec.encode(section.text)
+        overlap = min(128, max(1, budget // 10))
+        step = max(1, budget - overlap)
+        return [
+            section.model_copy(
+                update={"text": codec.decode(tokens[start : start + budget])}
+            )
+            for start in range(0, len(tokens), step)
+        ]
+
     async def _request_validated(
         self,
         prompt: str,
@@ -57,7 +120,12 @@ class ClaimExtractor:
         original_prompt = prompt
         last_error: Exception | None = None
         for attempt in range(1, self.max_retries + 1):
-            logger.info("%s: sending request (attempt %s/%s)", request_name, attempt, self.max_retries)
+            logger.info(
+                "%s: sending request (attempt %s/%s)",
+                request_name,
+                attempt,
+                self.max_retries,
+            )
             raw = await self.handler.async_request(current_prompt, system)
             logger.debug("Raw response:\n%s", raw)
             try:
@@ -70,14 +138,19 @@ class ClaimExtractor:
                 return parsed
             except (JsonParseError, ValueError, TypeError, ValidationError) as exc:
                 last_error = exc
-                logger.info("%s: response validation failed, preparing repair request", request_name)
+                logger.info(
+                    "%s: response validation failed, preparing repair request",
+                    request_name,
+                )
                 current_prompt = PromptBuilder.render(
                     self.prompts.get("paper_claims.repair"),
                     error=str(exc),
                     response=str(raw),
                     original_prompt=original_prompt,
                 )
-        raise ClaimExtractionError(f"LLM response remained invalid after {self.max_retries} attempts: {last_error}")
+        raise ClaimExtractionError(
+            f"LLM response remained invalid after {self.max_retries} attempts: {last_error}"
+        )
 
     async def _request_claim_candidates(
         self,
@@ -94,7 +167,12 @@ class ClaimExtractor:
         original_prompt = prompt
         last_error: Exception | None = None
         for attempt in range(1, self.max_retries + 1):
-            logger.info("%s: sending request (attempt %s/%s)", request_name, attempt, self.max_retries)
+            logger.info(
+                "%s: sending request (attempt %s/%s)",
+                request_name,
+                attempt,
+                self.max_retries,
+            )
             raw = await self.handler.async_request(current_prompt, system)
             logger.debug("Raw response:\n%s", raw)
             try:
@@ -102,7 +180,10 @@ class ClaimExtractor:
                 parsed = adapter.validate_python(data)
             except (JsonParseError, TypeError, ValidationError) as exc:
                 last_error = exc
-                logger.info("%s: response validation failed, preparing repair request", request_name)
+                logger.info(
+                    "%s: response validation failed, preparing repair request",
+                    request_name,
+                )
                 current_prompt = PromptBuilder.render(
                     self.prompts.get("paper_claims.repair"),
                     error=str(exc),
@@ -119,7 +200,10 @@ class ClaimExtractor:
 
             last_error = ValueError("; ".join(invalid))
             if attempt < self.max_retries:
-                logger.info("%s: response validation failed, preparing repair request", request_name)
+                logger.info(
+                    "%s: response validation failed, preparing repair request",
+                    request_name,
+                )
                 current_prompt = PromptBuilder.render(
                     self.prompts.get("paper_claims.repair"),
                     error=str(last_error),
@@ -129,7 +213,11 @@ class ClaimExtractor:
                 continue
 
             for error in invalid:
-                logger.info("%s: dropping invalid claim after final attempt: %s", request_name, error)
+                logger.info(
+                    "%s: dropping invalid claim after final attempt: %s",
+                    request_name,
+                    error,
+                )
             logger.info(
                 "%s: kept %s/%s claims after dropping invalid claims",
                 request_name,
@@ -139,11 +227,16 @@ class ClaimExtractor:
             logger.debug("Parsed response after dropping invalid claims:\n%s", valid)
             return valid
 
-        raise ClaimExtractionError(f"LLM response remained invalid after {self.max_retries} attempts: {last_error}")
+        raise ClaimExtractionError(
+            f"LLM response remained invalid after {self.max_retries} attempts: {last_error}"
+        )
 
     async def _step_1_select_sections(self, sections: list[PaperSection]) -> list[str]:
         """Select claim-bearing sections while preserving their source order."""
-        logger.info("Claim extraction step 1/3: selecting relevant sections from %s sections", len(sections))
+        logger.info(
+            "Claim extraction step 1/3: selecting relevant sections from %s sections",
+            len(sections),
+        )
         section_by_id = {section.section_id: section for section in sections}
         section_options = [
             {
@@ -156,7 +249,9 @@ class ClaimExtractor:
 
         def validate_sections(items: list[SelectedSectionResponse]) -> None:
             ids = [item.section_id for item in items]
-            if len(ids) != len(set(ids)) or any(item not in section_by_id for item in ids):
+            if len(ids) != len(set(ids)) or any(
+                item not in section_by_id for item in ids
+            ):
                 raise ValueError("Selection contains duplicate or unknown section IDs")
 
         selected = await self._request_validated(
@@ -170,8 +265,15 @@ class ClaimExtractor:
         )
         selected_ids = [item.section_id for item in selected]
         selected_set = set(selected_ids)
-        ordered_ids = [section.section_id for section in sections if section.section_id in selected_set]
-        logger.info("Claim extraction step 1/3 completed: selected %s sections", len(ordered_ids))
+        ordered_ids = [
+            section.section_id
+            for section in sections
+            if section.section_id in selected_set
+        ]
+        logger.info(
+            "Claim extraction step 1/3 completed: selected %s sections",
+            len(ordered_ids),
+        )
         return ordered_ids
 
     async def _step_2_extract_claims(
@@ -187,22 +289,37 @@ class ClaimExtractor:
         section_by_id = {section.section_id: section for section in sections}
         claims: list[ExtractedClaim] = []
         claim_adapter = TypeAdapter(list[ClaimCandidateResponse])
-        for section_id in track(selected_section_ids, description="Extracting section claims"):
+        for section_id in track(
+            selected_section_ids, description="Extracting section claims"
+        ):
             section = section_by_id[section_id]
             if not section.text.strip():
-                logger.info("Skipping empty selected section %s (%s)", section.section_id, section.name)
+                logger.info(
+                    "Skipping empty selected section %s (%s)",
+                    section.section_id,
+                    section.name,
+                )
                 continue
-            logger.info("Extracting claims from section %s (%s)", section.section_id, section.name)
-
-            candidates = await self._request_claim_candidates(
-                "Analyze the following paper section and extract all verifiable factual claims:\n"
-                + section.text
-                + "\nReturn ONLY the JSON array as specified in the system instructions.",
-                self.prompts.get("paper_claims.claim_extraction_system"),
-                claim_adapter,
-                section=section,
-                request_name=f"Claim extraction for section {section.section_id}",
+            logger.info(
+                "Extracting claims from section %s (%s)",
+                section.section_id,
+                section.name,
             )
+            extraction_system = self.prompts.get("paper_claims.claim_extraction_system")
+            candidates: list[ClaimCandidateResponse] = []
+            for chunk_index, chunk in enumerate(
+                self._section_chunks(section, extraction_system), start=1
+            ):
+                chunk_candidates = await self._request_claim_candidates(
+                    "Analyze the following paper section and extract all verifiable factual claims:\n"
+                    + chunk.text
+                    + "\nReturn ONLY the JSON array as specified in the system instructions.",
+                    extraction_system,
+                    claim_adapter,
+                    section=chunk,
+                    request_name=f"Claim extraction for section {section.section_id} chunk {chunk_index}",
+                )
+                candidates.extend(chunk_candidates)
             for candidate in candidates:
                 claims.append(
                     ExtractedClaim(
@@ -218,7 +335,9 @@ class ClaimExtractor:
                 section.section_id,
                 len(candidates),
             )
-        logger.info("Claim extraction step 2/3 completed: extracted %s claims", len(claims))
+        logger.info(
+            "Claim extraction step 2/3 completed: extracted %s claims", len(claims)
+        )
         return claims
 
     async def _step_3_deduplicate_claims(
@@ -236,7 +355,8 @@ class ClaimExtractor:
             self.dedup_batch_size,
         )
         batches = [
-            claims[index : index + self.dedup_batch_size] for index in range(0, len(claims), self.dedup_batch_size)
+            claims[index : index + self.dedup_batch_size]
+            for index in range(0, len(claims), self.dedup_batch_size)
         ]
         filtered: list[ExtractedClaim] = []
         selections: list[DedupSelection] = []
@@ -263,9 +383,29 @@ class ClaimExtractor:
                 )
             else:
                 logger.info(
-                    "Claim extraction step 3/3: skipping final global pass because %s survivors exceed batch_size=%s",
+                    "Claim extraction step 3/3: running cross-batch hierarchical pass over %s survivors",
                     len(filtered),
-                    self.dedup_batch_size,
+                )
+                # Interleave prior batches so boundary survivors are compared.
+                interleaved = [
+                    claim
+                    for offset in range(self.dedup_batch_size)
+                    for claim in filtered[offset :: self.dedup_batch_size]
+                ]
+                next_filtered: list[ExtractedClaim] = []
+                next_selections: list[DedupSelection] = []
+                for index in range(0, len(interleaved), self.dedup_batch_size):
+                    kept, chosen = await self._deduplicate_claim_batch(
+                        interleaved[index : index + self.dedup_batch_size],
+                        request_name="Claim deduplication hierarchical pass",
+                    )
+                    next_filtered.extend(kept)
+                    next_selections.extend(chosen)
+                filtered = sorted(
+                    next_filtered, key=lambda claim: int(claim.claim_id[1:])
+                )
+                selections = sorted(
+                    next_selections, key=lambda item: int(item.claim_id[1:])
                 )
 
         ratio = len(filtered) / len(claims)
@@ -284,19 +424,32 @@ class ClaimExtractor:
         request_name: str,
     ) -> tuple[list[ExtractedClaim], list[DedupSelection]]:
         """Deduplicate one bounded batch and fall back to preserving all claims on LLM failure."""
-        dedup_input = [{"claim_id": claim.claim_id, "claim": claim.claim} for claim in claims]
+        dedup_input = [
+            {"claim_id": claim.claim_id, "claim": claim.claim} for claim in claims
+        ]
         claims_by_id = {claim.claim_id: claim for claim in claims}
 
         def validate_dedup(items: list[DedupSelection]) -> None:
             if claims and not items:
-                raise ValueError(f"Deduplication returned 0 claims for non-empty input of {len(claims)} claims")
+                raise ValueError(
+                    f"Deduplication returned 0 claims for non-empty input of {len(claims)} claims"
+                )
             ids = [item.claim_id for item in items]
-            if len(ids) != len(set(ids)) or any(item not in claims_by_id for item in ids):
-                raise ValueError("Deduplication contains duplicate or unknown claim IDs")
-            rewritten = [item.claim_id for item in items if item.claim != claims_by_id[item.claim_id].claim]
+            if len(ids) != len(set(ids)) or any(
+                item not in claims_by_id for item in ids
+            ):
+                raise ValueError(
+                    "Deduplication contains duplicate or unknown claim IDs"
+                )
+            rewritten = [
+                item.claim_id
+                for item in items
+                if item.claim != claims_by_id[item.claim_id].claim
+            ]
             if rewritten:
                 raise ValueError(
-                    "Deduplication must copy claim text verbatim; rewritten claim IDs: " + ", ".join(rewritten)
+                    "Deduplication must copy claim text verbatim; rewritten claim IDs: "
+                    + ", ".join(rewritten)
                 )
 
         try:
@@ -309,12 +462,16 @@ class ClaimExtractor:
                 validate_dedup,
                 request_name=request_name,
             )
-        except ClaimExtractionError as exc:
-            return self._fallback_deduplication(claims, request_name=request_name, reason=str(exc))
+        except Exception as exc:
+            return self._fallback_deduplication(
+                claims, request_name=request_name, reason=str(exc)
+            )
 
         selection_by_id = {item.claim_id: item for item in selections}
         filtered = [
-            claim.model_copy(update={"contradiction": selection_by_id[claim.claim_id].contradiction})
+            claim.model_copy(
+                update={"contradiction": selection_by_id[claim.claim_id].contradiction}
+            )
             for claim in claims
             if claim.claim_id in selection_by_id
         ]
@@ -342,9 +499,14 @@ class ClaimExtractor:
             reason,
         )
         selections = [
-            DedupSelection(claim_id=claim.claim_id, claim=claim.claim, contradiction=False) for claim in claims
+            DedupSelection(
+                claim_id=claim.claim_id,
+                claim=claim.claim,
+                contradiction=claim.contradiction,
+            )
+            for claim in claims
         ]
-        filtered = [claim.model_copy(update={"contradiction": False}) for claim in claims]
+        filtered = list(claims)
         return filtered, selections
 
     async def extract(
@@ -361,8 +523,13 @@ class ClaimExtractor:
         logger.info("Starting three-step claim extraction")
         selected_ids = await self._step_1_select_sections(sections)
         extracted_claims = await self._step_2_extract_claims(sections, selected_ids)
-        filtered_claims, selections = await self._step_3_deduplicate_claims(extracted_claims)
-        logger.info("Three-step claim extraction completed: final_claims=%s", len(filtered_claims))
+        filtered_claims, selections = await self._step_3_deduplicate_claims(
+            extracted_claims
+        )
+        logger.info(
+            "Three-step claim extraction completed: final_claims=%s",
+            len(filtered_claims),
+        )
         actual_model = getattr(self.handler, "last_successful_model", None) or model
 
         return ClaimExtractionResult(

--- a/osa_tool/operations/analysis/paper_claims/claim_extractor.py
+++ b/osa_tool/operations/analysis/paper_claims/claim_extractor.py
@@ -28,9 +28,7 @@ from osa_tool.utils.token_counter import count_tokens
 
 
 class AsyncModelHandler(Protocol):
-    async def async_request(
-        self, prompt: str, system_message: str | None = None, retry_delay: float = 1
-    ) -> str: ...
+    async def async_request(self, prompt: str, system_message: str | None = None, retry_delay: float = 1) -> str: ...
 
 
 class ClaimExtractor:
@@ -54,18 +52,10 @@ class ClaimExtractor:
     def _section_chunks(self, section: PaperSection, system: str) -> list[PaperSection]:
         """Split a section to fit the handler input budget with a small overlap."""
         settings = getattr(self.handler, "model_settings", None)
-        if (
-            settings is None
-            or not hasattr(settings, "context_window")
-            or not hasattr(settings, "max_tokens")
-        ):
+        if settings is None or not hasattr(settings, "context_window") or not hasattr(settings, "max_tokens"):
             return [section]
         encoder = getattr(settings, "encoder", "cl100k_base")
-        total_input_budget = (
-            getattr(settings, "context_window", 0)
-            - getattr(settings, "max_tokens", 0)
-            - 256
-        )
+        total_input_budget = getattr(settings, "context_window", 0) - getattr(settings, "max_tokens", 0) - 256
         # A character is never less conservative than a token for ordinary
         # text; avoid loading an encoder at all for obviously short sections.
         if len(system) + len(section.text) <= total_input_budget:
@@ -84,9 +74,7 @@ class ClaimExtractor:
             overlap = min(128, max(1, budget // 10))
             step = max(1, budget - overlap)
             return [
-                section.model_copy(
-                    update={"text": section.text[start : start + budget]}
-                )
+                section.model_copy(update={"text": section.text[start : start + budget]})
                 for start in range(0, len(section.text), step)
             ]
 
@@ -100,9 +88,7 @@ class ClaimExtractor:
         overlap = min(128, max(1, budget // 10))
         step = max(1, budget - overlap)
         return [
-            section.model_copy(
-                update={"text": codec.decode(tokens[start : start + budget])}
-            )
+            section.model_copy(update={"text": codec.decode(tokens[start : start + budget])})
             for start in range(0, len(tokens), step)
         ]
 
@@ -148,9 +134,7 @@ class ClaimExtractor:
                     response=str(raw),
                     original_prompt=original_prompt,
                 )
-        raise ClaimExtractionError(
-            f"LLM response remained invalid after {self.max_retries} attempts: {last_error}"
-        )
+        raise ClaimExtractionError(f"LLM response remained invalid after {self.max_retries} attempts: {last_error}")
 
     async def _request_claim_candidates(
         self,
@@ -227,9 +211,7 @@ class ClaimExtractor:
             logger.debug("Parsed response after dropping invalid claims:\n%s", valid)
             return valid
 
-        raise ClaimExtractionError(
-            f"LLM response remained invalid after {self.max_retries} attempts: {last_error}"
-        )
+        raise ClaimExtractionError(f"LLM response remained invalid after {self.max_retries} attempts: {last_error}")
 
     async def _step_1_select_sections(self, sections: list[PaperSection]) -> list[str]:
         """Select claim-bearing sections while preserving their source order."""
@@ -249,9 +231,7 @@ class ClaimExtractor:
 
         def validate_sections(items: list[SelectedSectionResponse]) -> None:
             ids = [item.section_id for item in items]
-            if len(ids) != len(set(ids)) or any(
-                item not in section_by_id for item in ids
-            ):
+            if len(ids) != len(set(ids)) or any(item not in section_by_id for item in ids):
                 raise ValueError("Selection contains duplicate or unknown section IDs")
 
         selected = await self._request_validated(
@@ -265,11 +245,7 @@ class ClaimExtractor:
         )
         selected_ids = [item.section_id for item in selected]
         selected_set = set(selected_ids)
-        ordered_ids = [
-            section.section_id
-            for section in sections
-            if section.section_id in selected_set
-        ]
+        ordered_ids = [section.section_id for section in sections if section.section_id in selected_set]
         logger.info(
             "Claim extraction step 1/3 completed: selected %s sections",
             len(ordered_ids),
@@ -289,9 +265,7 @@ class ClaimExtractor:
         section_by_id = {section.section_id: section for section in sections}
         claims: list[ExtractedClaim] = []
         claim_adapter = TypeAdapter(list[ClaimCandidateResponse])
-        for section_id in track(
-            selected_section_ids, description="Extracting section claims"
-        ):
+        for section_id in track(selected_section_ids, description="Extracting section claims"):
             section = section_by_id[section_id]
             if not section.text.strip():
                 logger.info(
@@ -307,9 +281,7 @@ class ClaimExtractor:
             )
             extraction_system = self.prompts.get("paper_claims.claim_extraction_system")
             candidates: list[ClaimCandidateResponse] = []
-            for chunk_index, chunk in enumerate(
-                self._section_chunks(section, extraction_system), start=1
-            ):
+            for chunk_index, chunk in enumerate(self._section_chunks(section, extraction_system), start=1):
                 chunk_candidates = await self._request_claim_candidates(
                     "Analyze the following paper section and extract all verifiable factual claims:\n"
                     + chunk.text
@@ -335,9 +307,7 @@ class ClaimExtractor:
                 section.section_id,
                 len(candidates),
             )
-        logger.info(
-            "Claim extraction step 2/3 completed: extracted %s claims", len(claims)
-        )
+        logger.info("Claim extraction step 2/3 completed: extracted %s claims", len(claims))
         return claims
 
     async def _step_3_deduplicate_claims(
@@ -355,8 +325,7 @@ class ClaimExtractor:
             self.dedup_batch_size,
         )
         batches = [
-            claims[index : index + self.dedup_batch_size]
-            for index in range(0, len(claims), self.dedup_batch_size)
+            claims[index : index + self.dedup_batch_size] for index in range(0, len(claims), self.dedup_batch_size)
         ]
         filtered: list[ExtractedClaim] = []
         selections: list[DedupSelection] = []
@@ -401,12 +370,8 @@ class ClaimExtractor:
                     )
                     next_filtered.extend(kept)
                     next_selections.extend(chosen)
-                filtered = sorted(
-                    next_filtered, key=lambda claim: int(claim.claim_id[1:])
-                )
-                selections = sorted(
-                    next_selections, key=lambda item: int(item.claim_id[1:])
-                )
+                filtered = sorted(next_filtered, key=lambda claim: int(claim.claim_id[1:]))
+                selections = sorted(next_selections, key=lambda item: int(item.claim_id[1:]))
 
         ratio = len(filtered) / len(claims)
         logger.info(
@@ -424,32 +389,19 @@ class ClaimExtractor:
         request_name: str,
     ) -> tuple[list[ExtractedClaim], list[DedupSelection]]:
         """Deduplicate one bounded batch and fall back to preserving all claims on LLM failure."""
-        dedup_input = [
-            {"claim_id": claim.claim_id, "claim": claim.claim} for claim in claims
-        ]
+        dedup_input = [{"claim_id": claim.claim_id, "claim": claim.claim} for claim in claims]
         claims_by_id = {claim.claim_id: claim for claim in claims}
 
         def validate_dedup(items: list[DedupSelection]) -> None:
             if claims and not items:
-                raise ValueError(
-                    f"Deduplication returned 0 claims for non-empty input of {len(claims)} claims"
-                )
+                raise ValueError(f"Deduplication returned 0 claims for non-empty input of {len(claims)} claims")
             ids = [item.claim_id for item in items]
-            if len(ids) != len(set(ids)) or any(
-                item not in claims_by_id for item in ids
-            ):
-                raise ValueError(
-                    "Deduplication contains duplicate or unknown claim IDs"
-                )
-            rewritten = [
-                item.claim_id
-                for item in items
-                if item.claim != claims_by_id[item.claim_id].claim
-            ]
+            if len(ids) != len(set(ids)) or any(item not in claims_by_id for item in ids):
+                raise ValueError("Deduplication contains duplicate or unknown claim IDs")
+            rewritten = [item.claim_id for item in items if item.claim != claims_by_id[item.claim_id].claim]
             if rewritten:
                 raise ValueError(
-                    "Deduplication must copy claim text verbatim; rewritten claim IDs: "
-                    + ", ".join(rewritten)
+                    "Deduplication must copy claim text verbatim; rewritten claim IDs: " + ", ".join(rewritten)
                 )
 
         try:
@@ -463,15 +415,11 @@ class ClaimExtractor:
                 request_name=request_name,
             )
         except Exception as exc:
-            return self._fallback_deduplication(
-                claims, request_name=request_name, reason=str(exc)
-            )
+            return self._fallback_deduplication(claims, request_name=request_name, reason=str(exc))
 
         selection_by_id = {item.claim_id: item for item in selections}
         filtered = [
-            claim.model_copy(
-                update={"contradiction": selection_by_id[claim.claim_id].contradiction}
-            )
+            claim.model_copy(update={"contradiction": selection_by_id[claim.claim_id].contradiction})
             for claim in claims
             if claim.claim_id in selection_by_id
         ]
@@ -523,9 +471,7 @@ class ClaimExtractor:
         logger.info("Starting three-step claim extraction")
         selected_ids = await self._step_1_select_sections(sections)
         extracted_claims = await self._step_2_extract_claims(sections, selected_ids)
-        filtered_claims, selections = await self._step_3_deduplicate_claims(
-            extracted_claims
-        )
+        filtered_claims, selections = await self._step_3_deduplicate_claims(extracted_claims)
         logger.info(
             "Three-step claim extraction completed: final_claims=%s",
             len(filtered_claims),

--- a/osa_tool/operations/analysis/paper_claims/claim_validation.py
+++ b/osa_tool/operations/analysis/paper_claims/claim_validation.py
@@ -81,9 +81,7 @@ def _candidate_source_spans(section_text: str) -> list[str]:
     return candidates
 
 
-def _find_fuzzy_source_match(
-    section_text: str, original_text: str
-) -> _SourceTextMatch | None:
+def _find_fuzzy_source_match(section_text: str, original_text: str) -> _SourceTextMatch | None:
     if len(original_text.strip()) < _FUZZY_SOURCE_MIN_CHARS:
         return None
     candidates = _candidate_source_spans(section_text)
@@ -105,18 +103,13 @@ def _find_fuzzy_source_match(
     # High edit similarity can conceal a materially different measurement.
     # Never "repair" numbers or identifiers containing digits.
     def semantic_tokens(value: str) -> list[str]:
-        return re.findall(
-            r"(?<!\w)[+-]?(?:\d+(?:[.,]\d+)?(?:e[+-]?\d+)?|\w*\d\w*)(?!\w)", value, re.I
-        )
+        return re.findall(r"(?<!\w)[+-]?(?:\d+(?:[.,]\d+)?(?:e[+-]?\d+)?|\w*\d\w*)(?!\w)", value, re.I)
 
     if semantic_tokens(original_text) != semantic_tokens(best_text):
         return None
     if len(matches) > 1:
         second_text, second_score, _second_index = matches[1]
-        if (
-            second_text != best_text
-            and best_score - second_score <= _FUZZY_SOURCE_AMBIGUITY_MARGIN
-        ):
+        if second_text != best_text and best_score - second_score <= _FUZZY_SOURCE_AMBIGUITY_MARGIN:
             logger.debug(
                 "Fuzzy original_text repair is ambiguous. best_score=%.1f; second_score=%.1f; "
                 "best_text=%r; second_text=%r",
@@ -129,9 +122,7 @@ def _find_fuzzy_source_match(
     return _SourceTextMatch(best_text, method="fuzzy", similarity=best_score / 100)
 
 
-def _find_original_source_match(
-    section_text: str, original_text: str
-) -> _SourceTextMatch | None:
+def _find_original_source_match(section_text: str, original_text: str) -> _SourceTextMatch | None:
     """Return an exact source span, or a conservative RapidFuzz-backed repair."""
     if original_text in section_text:
         return _SourceTextMatch(original_text, method="exact")
@@ -161,11 +152,7 @@ def _script_profile(text: str) -> _ScriptProfile:
             continue
         unicode_name = unicodedata.name(character, "")
         script = next(
-            (
-                script
-                for script, markers in script_markers.items()
-                if any(marker in unicode_name for marker in markers)
-            ),
+            (script for script, markers in script_markers.items() if any(marker in unicode_name for marker in markers)),
             None,
         )
         if script is None and unicode_name:
@@ -179,48 +166,31 @@ def _script_profile(text: str) -> _ScriptProfile:
         return _ScriptProfile(script=None, letters=0, dominance=0.0)
     letters = sum(scripts.values())
     dominant = max(scripts, key=scripts.get)
-    return _ScriptProfile(
-        script=dominant, letters=letters, dominance=scripts[dominant] / letters
-    )
+    return _ScriptProfile(script=dominant, letters=letters, dominance=scripts[dominant] / letters)
 
 
 def _is_reliable_script(profile: _ScriptProfile, *, min_letters: int) -> bool:
-    return (
-        profile.script is not None
-        and profile.letters >= min_letters
-        and profile.dominance >= _MIN_SCRIPT_DOMINANCE
-    )
+    return profile.script is not None and profile.letters >= min_letters and profile.dominance >= _MIN_SCRIPT_DOMINANCE
 
 
 def _format_script_profile(profile: _ScriptProfile) -> str:
     return f"{profile.script or 'unknown'} letters={profile.letters} dominance={profile.dominance:.2f}"
 
 
-def _validate_claim_script(
-    *, item: ClaimCandidateResponse, section: PaperSection, source_text: str
-) -> None:
+def _validate_claim_script(*, item: ClaimCandidateResponse, section: PaperSection, source_text: str) -> None:
     section_profile = _script_profile(section.text)
     source_profile = _script_profile(source_text)
     claim_profile = _script_profile(item.claim)
-    if not _is_reliable_script(
-        claim_profile, min_letters=_MIN_RELIABLE_CLAIM_SCRIPT_LETTERS
-    ):
+    if not _is_reliable_script(claim_profile, min_letters=_MIN_RELIABLE_CLAIM_SCRIPT_LETTERS):
         return
 
     allowed_scripts: set[str] = set()
     if (
-        _is_reliable_script(
-            section_profile, min_letters=_MIN_RELIABLE_CONTEXT_SCRIPT_LETTERS
-        )
+        _is_reliable_script(section_profile, min_letters=_MIN_RELIABLE_CONTEXT_SCRIPT_LETTERS)
         and section_profile.script
     ):
         allowed_scripts.add(section_profile.script)
-    if (
-        _is_reliable_script(
-            source_profile, min_letters=_MIN_RELIABLE_CONTEXT_SCRIPT_LETTERS
-        )
-        and source_profile.script
-    ):
+    if _is_reliable_script(source_profile, min_letters=_MIN_RELIABLE_CONTEXT_SCRIPT_LETTERS) and source_profile.script:
         allowed_scripts.add(source_profile.script)
     if not allowed_scripts or claim_profile.script in allowed_scripts:
         return
@@ -234,9 +204,7 @@ def _validate_claim_script(
     )
 
 
-def validate_claim_candidate(
-    item: ClaimCandidateResponse, *, section: PaperSection
-) -> None:
+def validate_claim_candidate(item: ClaimCandidateResponse, *, section: PaperSection) -> None:
     source_match = _find_original_source_match(section.text, item.original_text)
     if source_match is None:
         logger.debug(

--- a/osa_tool/operations/analysis/paper_claims/claim_validation.py
+++ b/osa_tool/operations/analysis/paper_claims/claim_validation.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import unicodedata
+import re
 from dataclasses import dataclass
 
 from rapidfuzz import fuzz, process
 
-from osa_tool.operations.analysis.paper_claims.claim_schemas import ClaimCandidateResponse
+from osa_tool.operations.analysis.paper_claims.claim_schemas import (
+    ClaimCandidateResponse,
+)
 from osa_tool.operations.analysis.paper_claims.models import PaperSection
 from osa_tool.utils.logger import logger
 
@@ -78,7 +81,9 @@ def _candidate_source_spans(section_text: str) -> list[str]:
     return candidates
 
 
-def _find_fuzzy_source_match(section_text: str, original_text: str) -> _SourceTextMatch | None:
+def _find_fuzzy_source_match(
+    section_text: str, original_text: str
+) -> _SourceTextMatch | None:
     if len(original_text.strip()) < _FUZZY_SOURCE_MIN_CHARS:
         return None
     candidates = _candidate_source_spans(section_text)
@@ -96,9 +101,22 @@ def _find_fuzzy_source_match(section_text: str, original_text: str) -> _SourceTe
         return None
 
     best_text, best_score, _best_index = matches[0]
+
+    # High edit similarity can conceal a materially different measurement.
+    # Never "repair" numbers or identifiers containing digits.
+    def semantic_tokens(value: str) -> list[str]:
+        return re.findall(
+            r"(?<!\w)[+-]?(?:\d+(?:[.,]\d+)?(?:e[+-]?\d+)?|\w*\d\w*)(?!\w)", value, re.I
+        )
+
+    if semantic_tokens(original_text) != semantic_tokens(best_text):
+        return None
     if len(matches) > 1:
         second_text, second_score, _second_index = matches[1]
-        if second_text != best_text and best_score - second_score <= _FUZZY_SOURCE_AMBIGUITY_MARGIN:
+        if (
+            second_text != best_text
+            and best_score - second_score <= _FUZZY_SOURCE_AMBIGUITY_MARGIN
+        ):
             logger.debug(
                 "Fuzzy original_text repair is ambiguous. best_score=%.1f; second_score=%.1f; "
                 "best_text=%r; second_text=%r",
@@ -111,7 +129,9 @@ def _find_fuzzy_source_match(section_text: str, original_text: str) -> _SourceTe
     return _SourceTextMatch(best_text, method="fuzzy", similarity=best_score / 100)
 
 
-def _find_original_source_match(section_text: str, original_text: str) -> _SourceTextMatch | None:
+def _find_original_source_match(
+    section_text: str, original_text: str
+) -> _SourceTextMatch | None:
     """Return an exact source span, or a conservative RapidFuzz-backed repair."""
     if original_text in section_text:
         return _SourceTextMatch(original_text, method="exact")
@@ -141,40 +161,66 @@ def _script_profile(text: str) -> _ScriptProfile:
             continue
         unicode_name = unicodedata.name(character, "")
         script = next(
-            (script for script, markers in script_markers.items() if any(marker in unicode_name for marker in markers)),
+            (
+                script
+                for script, markers in script_markers.items()
+                if any(marker in unicode_name for marker in markers)
+            ),
             None,
         )
+        if script is None and unicode_name:
+            # Unicode letter names normally begin with their script (for
+            # example GREEK and DEVANAGARI), so retain scripts not in the
+            # small set of aliases above instead of treating them as unknown.
+            script = unicode_name.split()[0]
         if script:
             scripts[script] = scripts.get(script, 0) + 1
     if not scripts:
         return _ScriptProfile(script=None, letters=0, dominance=0.0)
     letters = sum(scripts.values())
     dominant = max(scripts, key=scripts.get)
-    return _ScriptProfile(script=dominant, letters=letters, dominance=scripts[dominant] / letters)
+    return _ScriptProfile(
+        script=dominant, letters=letters, dominance=scripts[dominant] / letters
+    )
 
 
 def _is_reliable_script(profile: _ScriptProfile, *, min_letters: int) -> bool:
-    return profile.script is not None and profile.letters >= min_letters and profile.dominance >= _MIN_SCRIPT_DOMINANCE
+    return (
+        profile.script is not None
+        and profile.letters >= min_letters
+        and profile.dominance >= _MIN_SCRIPT_DOMINANCE
+    )
 
 
 def _format_script_profile(profile: _ScriptProfile) -> str:
     return f"{profile.script or 'unknown'} letters={profile.letters} dominance={profile.dominance:.2f}"
 
 
-def _validate_claim_script(*, item: ClaimCandidateResponse, section: PaperSection, source_text: str) -> None:
+def _validate_claim_script(
+    *, item: ClaimCandidateResponse, section: PaperSection, source_text: str
+) -> None:
     section_profile = _script_profile(section.text)
     source_profile = _script_profile(source_text)
     claim_profile = _script_profile(item.claim)
-    if not _is_reliable_script(claim_profile, min_letters=_MIN_RELIABLE_CLAIM_SCRIPT_LETTERS):
+    if not _is_reliable_script(
+        claim_profile, min_letters=_MIN_RELIABLE_CLAIM_SCRIPT_LETTERS
+    ):
         return
 
     allowed_scripts: set[str] = set()
     if (
-        _is_reliable_script(section_profile, min_letters=_MIN_RELIABLE_CONTEXT_SCRIPT_LETTERS)
+        _is_reliable_script(
+            section_profile, min_letters=_MIN_RELIABLE_CONTEXT_SCRIPT_LETTERS
+        )
         and section_profile.script
     ):
         allowed_scripts.add(section_profile.script)
-    if _is_reliable_script(source_profile, min_letters=_MIN_RELIABLE_CONTEXT_SCRIPT_LETTERS) and source_profile.script:
+    if (
+        _is_reliable_script(
+            source_profile, min_letters=_MIN_RELIABLE_CONTEXT_SCRIPT_LETTERS
+        )
+        and source_profile.script
+    ):
         allowed_scripts.add(source_profile.script)
     if not allowed_scripts or claim_profile.script in allowed_scripts:
         return
@@ -188,7 +234,9 @@ def _validate_claim_script(*, item: ClaimCandidateResponse, section: PaperSectio
     )
 
 
-def validate_claim_candidate(item: ClaimCandidateResponse, *, section: PaperSection) -> None:
+def validate_claim_candidate(
+    item: ClaimCandidateResponse, *, section: PaperSection
+) -> None:
     source_match = _find_original_source_match(section.text, item.original_text)
     if source_match is None:
         logger.debug(

--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -1152,14 +1152,12 @@ class DocGen(object):
                 else:
                     docstring = component["details"]["docstring"] if component["details"]["docstring"] else ""
 
-                prompt_structure.append(
-                    f"""
+                prompt_structure.append(f"""
                     {_type.capitalize()} name: {component["name"] if _type == "class" else component["details"]["method_name"]}
                     Component description: {docstring}
                     Component place in hierarchy: {file}
                     Component importance score: {score}
-                    """
-                )
+                    """)
 
         logger.info(f"Generating the main idea of the project...")
 

--- a/osa_tool/tools/paper_claims/batch.py
+++ b/osa_tool/tools/paper_claims/batch.py
@@ -20,11 +20,7 @@ def collect_pdf_inputs(paths: list[Path]) -> tuple[list[Path], list[str]]:
     for raw_path in paths:
         path = raw_path.expanduser().resolve()
         if path.is_dir():
-            pdfs = {
-                item
-                for item in path.iterdir()
-                if item.is_file() and item.suffix.lower() == ".pdf"
-            }
+            pdfs = {item for item in path.iterdir() if item.is_file() and item.suffix.lower() == ".pdf"}
             if not pdfs:
                 failures.append(f"{raw_path}: directory contains no PDF files")
             collected.update(pdfs)
@@ -36,9 +32,7 @@ def collect_pdf_inputs(paths: list[Path]) -> tuple[list[Path], list[str]]:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Run claim extraction for multiple PDF documents."
-    )
+    parser = argparse.ArgumentParser(description="Run claim extraction for multiple PDF documents.")
     parser.add_argument("pdfs", nargs="+", type=Path)
     parser.add_argument("--output-dir", type=Path, default=Path("paper_claim_results"))
     parser.add_argument("--repository", default="https://github.com/ai-chem/DiMag")
@@ -98,9 +92,7 @@ def main() -> int:
             logger.info("Input rejected: %s", failure)
         return 1
     logger.info("Collected %s PDF documents for processing", len(pdfs))
-    stem_counts = {
-        pdf.stem: sum(other.stem == pdf.stem for other in pdfs) for pdf in pdfs
-    }
+    stem_counts = {pdf.stem: sum(other.stem == pdf.stem for other in pdfs) for pdf in pdfs}
     # NOTE: heavy LLM imports inside main() so parser/help can load without importing the full LLM stack
     from osa_tool.config.settings import ConfigManager
     from osa_tool.core.llm.llm import ModelHandlerFactory

--- a/osa_tool/tools/paper_claims/batch.py
+++ b/osa_tool/tools/paper_claims/batch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 from pathlib import Path
 
 from rich.progress import track
@@ -19,7 +20,11 @@ def collect_pdf_inputs(paths: list[Path]) -> tuple[list[Path], list[str]]:
     for raw_path in paths:
         path = raw_path.expanduser().resolve()
         if path.is_dir():
-            pdfs = {item for item in path.iterdir() if item.is_file() and item.suffix.lower() == ".pdf"}
+            pdfs = {
+                item
+                for item in path.iterdir()
+                if item.is_file() and item.suffix.lower() == ".pdf"
+            }
             if not pdfs:
                 failures.append(f"{raw_path}: directory contains no PDF files")
             collected.update(pdfs)
@@ -31,7 +36,9 @@ def collect_pdf_inputs(paths: list[Path]) -> tuple[list[Path], list[str]]:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run claim extraction for multiple PDF documents.")
+    parser = argparse.ArgumentParser(
+        description="Run claim extraction for multiple PDF documents."
+    )
     parser.add_argument("pdfs", nargs="+", type=Path)
     parser.add_argument("--output-dir", type=Path, default=Path("paper_claim_results"))
     parser.add_argument("--repository", default="https://github.com/ai-chem/DiMag")
@@ -91,6 +98,9 @@ def main() -> int:
             logger.info("Input rejected: %s", failure)
         return 1
     logger.info("Collected %s PDF documents for processing", len(pdfs))
+    stem_counts = {
+        pdf.stem: sum(other.stem == pdf.stem for other in pdfs) for pdf in pdfs
+    }
     # NOTE: heavy LLM imports inside main() so parser/help can load without importing the full LLM stack
     from osa_tool.config.settings import ConfigManager
     from osa_tool.core.llm.llm import ModelHandlerFactory
@@ -113,9 +123,13 @@ def main() -> int:
         logger.info("Starting document %s", pdf)
         try:
             result = pipeline.run(pdf, options)
+            output_name = pdf.stem
+            if stem_counts[pdf.stem] > 1:
+                digest = hashlib.sha256(str(pdf).encode()).hexdigest()[:10]
+                output_name = f"{pdf.stem}-{digest}"
             output_path = pipeline.export(
                 result,
-                args.output_dir / pdf.stem,
+                args.output_dir / output_name,
                 legacy=True,
                 include_debug=args.include_debug,
             )

--- a/osa_tool/tools/paper_claims/evaluate.py
+++ b/osa_tool/tools/paper_claims/evaluate.py
@@ -15,12 +15,8 @@ def load_claims(
     llm_data = json.loads(Path(llm_path).read_text(encoding="utf-8"))
     human_data = json.loads(Path(human_path).read_text(encoding="utf-8"))
     llm_items = llm_data.get("result", llm_data.get("claims", []))
-    llm_claims = [
-        str(item[llm_field]).strip() for item in llm_items if item.get(llm_field)
-    ]
-    human_claims = [
-        str(item).strip() for item in human_data.get("claims", []) if str(item).strip()
-    ]
+    llm_claims = [str(item[llm_field]).strip() for item in llm_items if item.get(llm_field)]
+    human_claims = [str(item).strip() for item in human_data.get("claims", []) if str(item).strip()]
     return llm_claims, human_claims
 
 
@@ -58,12 +54,8 @@ def compute_semantic_matching(
         ) from exc
 
     embedding_model = model or SentenceTransformer(model_name)
-    llm_embeddings = embedding_model.encode(
-        llm_claims, convert_to_numpy=True, normalize_embeddings=True
-    )
-    human_embeddings = embedding_model.encode(
-        human_claims, convert_to_numpy=True, normalize_embeddings=True
-    )
+    llm_embeddings = embedding_model.encode(llm_claims, convert_to_numpy=True, normalize_embeddings=True)
+    human_embeddings = embedding_model.encode(human_claims, convert_to_numpy=True, normalize_embeddings=True)
     similarities = np.dot(llm_embeddings, human_embeddings.T)
 
     if matching == "one_to_one":
@@ -73,11 +65,7 @@ def compute_semantic_matching(
         cardinality_bonus = min(similarities.shape) + 1
         scores = np.where(valid, cardinality_bonus + similarities, 0.0)
         rows, columns = linear_sum_assignment(-scores)
-        true_positives = sum(
-            1
-            for row, column in zip(rows, columns)
-            if similarities[row, column] >= threshold
-        )
+        true_positives = sum(1 for row, column in zip(rows, columns) if similarities[row, column] >= threshold)
         false_positives = len(llm_claims) - true_positives
     else:
         best_indices = np.argmax(similarities, axis=1)
@@ -87,12 +75,8 @@ def compute_semantic_matching(
         false_positives = len(llm_claims) - true_positives
         covered_humans = {int(best_indices[row]) for row in matched_rows}
 
-    precision = (
-        true_positives / (true_positives + false_positives) if llm_claims else 0.0
-    )
-    recall_numerator = (
-        true_positives if matching == "one_to_one" else len(covered_humans)
-    )
+    precision = true_positives / (true_positives + false_positives) if llm_claims else 0.0
+    recall_numerator = true_positives if matching == "one_to_one" else len(covered_humans)
     recall = recall_numerator / len(human_claims) if human_claims else 0.0
     f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
     return {
@@ -107,24 +91,16 @@ def compute_semantic_matching(
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Evaluate extracted claims against human annotations."
-    )
+    parser = argparse.ArgumentParser(description="Evaluate extracted claims against human annotations.")
     parser.add_argument("--llm", type=Path, required=True)
     parser.add_argument("--human", type=Path, required=True)
     parser.add_argument("--output", type=Path, default=Path("evaluation_result.json"))
     parser.add_argument("--threshold", type=float, default=0.75)
     parser.add_argument("--model", default="paraphrase-multilingual-MiniLM-L12-v2")
-    parser.add_argument(
-        "--llm-field", choices=["original_text", "claim"], default="original_text"
-    )
-    parser.add_argument(
-        "--matching", choices=["one_to_one", "many_to_one"], default="many_to_one"
-    )
+    parser.add_argument("--llm-field", choices=["original_text", "claim"], default="original_text")
+    parser.add_argument("--matching", choices=["one_to_one", "many_to_one"], default="many_to_one")
     args = parser.parse_args()
-    llm_claims, human_claims = load_claims(
-        args.llm, args.human, llm_field=args.llm_field
-    )
+    llm_claims, human_claims = load_claims(args.llm, args.human, llm_field=args.llm_field)
     metrics = compute_semantic_matching(
         llm_claims,
         human_claims,
@@ -144,9 +120,7 @@ def main() -> int:
         },
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(
-        json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8"
-    )
+    args.output.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
     return 0
 
 

--- a/osa_tool/tools/paper_claims/evaluate.py
+++ b/osa_tool/tools/paper_claims/evaluate.py
@@ -15,8 +15,12 @@ def load_claims(
     llm_data = json.loads(Path(llm_path).read_text(encoding="utf-8"))
     human_data = json.loads(Path(human_path).read_text(encoding="utf-8"))
     llm_items = llm_data.get("result", llm_data.get("claims", []))
-    llm_claims = [str(item[llm_field]).strip() for item in llm_items if item.get(llm_field)]
-    human_claims = [str(item).strip() for item in human_data.get("claims", []) if str(item).strip()]
+    llm_claims = [
+        str(item[llm_field]).strip() for item in llm_items if item.get(llm_field)
+    ]
+    human_claims = [
+        str(item).strip() for item in human_data.get("claims", []) if str(item).strip()
+    ]
     return llm_claims, human_claims
 
 
@@ -54,15 +58,27 @@ def compute_semantic_matching(
         ) from exc
 
     embedding_model = model or SentenceTransformer(model_name)
-    llm_embeddings = embedding_model.encode(llm_claims, convert_to_numpy=True, normalize_embeddings=True)
-    human_embeddings = embedding_model.encode(human_claims, convert_to_numpy=True, normalize_embeddings=True)
+    llm_embeddings = embedding_model.encode(
+        llm_claims, convert_to_numpy=True, normalize_embeddings=True
+    )
+    human_embeddings = embedding_model.encode(
+        human_claims, convert_to_numpy=True, normalize_embeddings=True
+    )
     similarities = np.dot(llm_embeddings, human_embeddings.T)
 
     if matching == "one_to_one":
-        rows, columns = linear_sum_assignment(1 - similarities)
-        true_positives = sum(1 for row, column in zip(rows, columns) if similarities[row, column] >= threshold)
+        # Cardinality has priority over similarity: one valid edge is worth more
+        # than the total possible similarity difference across an assignment.
+        valid = similarities >= threshold
+        cardinality_bonus = min(similarities.shape) + 1
+        scores = np.where(valid, cardinality_bonus + similarities, 0.0)
+        rows, columns = linear_sum_assignment(-scores)
+        true_positives = sum(
+            1
+            for row, column in zip(rows, columns)
+            if similarities[row, column] >= threshold
+        )
         false_positives = len(llm_claims) - true_positives
-        false_negatives = len(human_claims) - true_positives
     else:
         best_indices = np.argmax(similarities, axis=1)
         best_scores = similarities[np.arange(similarities.shape[0]), best_indices]
@@ -70,10 +86,14 @@ def compute_semantic_matching(
         true_positives = int(len(matched_rows))
         false_positives = len(llm_claims) - true_positives
         covered_humans = {int(best_indices[row]) for row in matched_rows}
-        false_negatives = len(human_claims) - len(covered_humans)
 
-    precision = true_positives / (true_positives + false_positives) if llm_claims else 0.0
-    recall = true_positives / (true_positives + false_negatives) if human_claims else 0.0
+    precision = (
+        true_positives / (true_positives + false_positives) if llm_claims else 0.0
+    )
+    recall_numerator = (
+        true_positives if matching == "one_to_one" else len(covered_humans)
+    )
+    recall = recall_numerator / len(human_claims) if human_claims else 0.0
     f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
     return {
         "precision": round(float(precision), 4),
@@ -87,16 +107,24 @@ def compute_semantic_matching(
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Evaluate extracted claims against human annotations.")
+    parser = argparse.ArgumentParser(
+        description="Evaluate extracted claims against human annotations."
+    )
     parser.add_argument("--llm", type=Path, required=True)
     parser.add_argument("--human", type=Path, required=True)
     parser.add_argument("--output", type=Path, default=Path("evaluation_result.json"))
     parser.add_argument("--threshold", type=float, default=0.75)
     parser.add_argument("--model", default="paraphrase-multilingual-MiniLM-L12-v2")
-    parser.add_argument("--llm-field", choices=["original_text", "claim"], default="original_text")
-    parser.add_argument("--matching", choices=["one_to_one", "many_to_one"], default="many_to_one")
+    parser.add_argument(
+        "--llm-field", choices=["original_text", "claim"], default="original_text"
+    )
+    parser.add_argument(
+        "--matching", choices=["one_to_one", "many_to_one"], default="many_to_one"
+    )
     args = parser.parse_args()
-    llm_claims, human_claims = load_claims(args.llm, args.human, llm_field=args.llm_field)
+    llm_claims, human_claims = load_claims(
+        args.llm, args.human, llm_field=args.llm_field
+    )
     metrics = compute_semantic_matching(
         llm_claims,
         human_claims,
@@ -116,7 +144,9 @@ def main() -> int:
         },
     }
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8")
+    args.output.write_text(
+        json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
     return 0
 
 

--- a/osa_tool/utils/response_cleaner.py
+++ b/osa_tool/utils/response_cleaner.py
@@ -16,10 +16,7 @@ class JsonProcessor:
                 continue
             candidate = match.group(2).strip()
             spans = [
-                span
-                for char in ("{", "[")
-                if (span := JsonProcessor._find_balanced_span(candidate, char))
-                is not None
+                span for char in ("{", "[") if (span := JsonProcessor._find_balanced_span(candidate, char)) is not None
             ]
             if not spans:
                 continue
@@ -101,9 +98,7 @@ class JsonProcessor:
             preferred = ["{"]
         else:
             # With no type information, preserve the outermost/earliest JSON root.
-            starts = [
-                (text.find(char), char) for char in ("{", "[") if text.find(char) >= 0
-            ]
+            starts = [(text.find(char), char) for char in ("{", "[") if text.find(char) >= 0]
             preferred = [char for _index, char in sorted(starts)]
 
         for open_char in preferred + [c for c in ["[", "{"] if c not in preferred]:
@@ -149,9 +144,7 @@ class JsonProcessor:
         """
         try:
             # expected_type applies after expected_key lookup, not to the keyed envelope.
-            cleaned = cls.process_text(
-                text, expected_type=dict if expected_key else expected_type
-            )
+            cleaned = cls.process_text(text, expected_type=dict if expected_key else expected_type)
             parsed = json.loads(cleaned)
 
             if expected_key:

--- a/osa_tool/utils/response_cleaner.py
+++ b/osa_tool/utils/response_cleaner.py
@@ -9,9 +9,31 @@ class JsonProcessor:
 
     @staticmethod
     def _extract_from_fence(text: str) -> str | None:
-        match = re.search(r"```(?:json)?\s*(.*?)\s*```", text, flags=re.IGNORECASE | re.DOTALL)
-        if match:
-            return match.group(1).strip()
+        candidates: list[tuple[bool, str]] = []
+        for match in re.finditer(r"```([^\n`]*)\n(.*?)```", text, flags=re.DOTALL):
+            language = match.group(1).strip().lower()
+            if language not in {"", "json"}:
+                continue
+            candidate = match.group(2).strip()
+            spans = [
+                span
+                for char in ("{", "[")
+                if (span := JsonProcessor._find_balanced_span(candidate, char))
+                is not None
+            ]
+            if not spans:
+                continue
+            start, end = min(spans, key=lambda span: span[0])
+            payload = candidate[start : end + 1]
+            try:
+                json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            candidates.append((language == "json", payload))
+        for explicitly_json in (True, False):
+            for is_json, payload in candidates:
+                if is_json == explicitly_json:
+                    return payload
         return None
 
     @staticmethod
@@ -61,10 +83,6 @@ class JsonProcessor:
         # Strip raw control characters that are invalid in JSON string values.
         # Preserves \t (0x09), \n (0x0A), \r (0x0D) which JSON parsers accept unescaped.
         text = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f]", "", text)
-        fenced = JsonProcessor._extract_from_fence(text)
-        if fenced:
-            text = fenced
-
         replacements = {"None": "null", "True": "true", "False": "false"}
         for key, value in replacements.items():
             text = text.replace(key, value)
@@ -72,6 +90,9 @@ class JsonProcessor:
         # remove trailing commas before closing braces/brackets
         text = re.sub(r",\s*([}\]])", r"\1", text)
         text = text.strip()
+        fenced = JsonProcessor._extract_from_fence(text)
+        if fenced:
+            text = fenced
 
         preferred: list[str]
         if expected_type is list:
@@ -79,7 +100,11 @@ class JsonProcessor:
         elif expected_type is dict:
             preferred = ["{"]
         else:
-            preferred = ["[", "{"]
+            # With no type information, preserve the outermost/earliest JSON root.
+            starts = [
+                (text.find(char), char) for char in ("{", "[") if text.find(char) >= 0
+            ]
+            preferred = [char for _index, char in sorted(starts)]
 
         for open_char in preferred + [c for c in ["[", "{"] if c not in preferred]:
             span = JsonProcessor._find_balanced_span(text, open_char)
@@ -123,7 +148,10 @@ class JsonProcessor:
             Parsed content (dict | list | str) depending on context.
         """
         try:
-            cleaned = cls.process_text(text, expected_type=expected_type)
+            # expected_type applies after expected_key lookup, not to the keyed envelope.
+            cleaned = cls.process_text(
+                text, expected_type=dict if expected_key else expected_type
+            )
             parsed = json.loads(cleaned)
 
             if expected_key:

--- a/tests/unit/operations/analysis/paper_claims/test_claim_extractor.py
+++ b/tests/unit/operations/analysis/paper_claims/test_claim_extractor.py
@@ -77,14 +77,11 @@ async def test_extract_repairs_invalid_source_text_and_deduplicates():
             '[{"section_id":"s001"}]',
             json.dumps([{**valid_claim, "original_text": "invented sentence"}]),
             json.dumps([valid_claim]),
-            '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",'
-            '"contradiction":false}]',
+            '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",' '"contradiction":false}]',
         ]
     )
 
-    result = await ClaimExtractor(handler, max_retries=2).extract(
-        [section()], source="paper.pdf", model="test"
-    )
+    result = await ClaimExtractor(handler, max_retries=2).extract([section()], source="paper.pdf", model="test")
 
     assert len(result.claims) == 1
     assert result.claims[0].section_name == "Method"
@@ -107,8 +104,7 @@ async def test_extract_accepts_layout_only_source_text_differences():
         [
             '[{"section_id":"s001"}]',
             json.dumps([candidate]),
-            '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",'
-            '"contradiction":false}]',
+            '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",' '"contradiction":false}]',
         ]
     )
 
@@ -264,8 +260,7 @@ async def test_extract_accepts_russian_claim_for_short_latin_technical_evidence(
 @pytest.mark.asyncio
 async def test_extract_drops_bad_claim_after_retries_and_keeps_valid_claim():
     source_text = (
-        "The model uses BERT-base without fine-tuning. "
-        "The retrieval pipeline uses BM25 for candidate selection."
+        "The model uses BERT-base without fine-tuning. " "The retrieval pipeline uses BM25 for candidate selection."
     )
     paper_section = section().model_copy(update={"text": source_text})
     valid_claim = {
@@ -322,8 +317,7 @@ async def test_extract_repairs_claim_written_in_a_different_script():
             '[{"section_id":"s001"}]',
             json.dumps([chinese_claim], ensure_ascii=False),
             json.dumps([valid_claim]),
-            '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",'
-            '"contradiction":false}]',
+            '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",' '"contradiction":false}]',
         ]
     )
 
@@ -343,8 +337,7 @@ async def test_deduplication_repairs_rewritten_claim_text():
         "verifiability": "high",
     }
     correct_dedup = (
-        '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",'
-        '"contradiction":false}]'
+        '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",' '"contradiction":false}]'
     )
     handler = FakeHandler(
         [
@@ -372,8 +365,7 @@ async def test_deduplication_repairs_empty_response_for_non_empty_input():
         "verifiability": "high",
     }
     correct_dedup = (
-        '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",'
-        '"contradiction":false}]'
+        '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",' '"contradiction":false}]'
     )
     handler = FakeHandler(
         [
@@ -392,10 +384,7 @@ async def test_deduplication_repairs_empty_response_for_non_empty_input():
 
 @pytest.mark.asyncio
 async def test_deduplication_falls_back_after_retries_and_keeps_original_claims():
-    source_text = (
-        "The pipeline uses chunked PDF processing. "
-        "The pipeline caches Marker Markdown output."
-    )
+    source_text = "The pipeline uses chunked PDF processing. " "The pipeline caches Marker Markdown output."
     paper_section = section().model_copy(update={"text": source_text})
     candidates = [
         {
@@ -575,9 +564,7 @@ async def test_failed_deduplication_batch_does_not_erase_successful_batches():
         ]
     )
 
-    result = await ClaimExtractor(handler, max_retries=1, dedup_batch_size=2).extract(
-        [paper_section]
-    )
+    result = await ClaimExtractor(handler, max_retries=1, dedup_batch_size=2).extract([paper_section])
 
     assert [claim.claim_id for claim in result.claims] == ["c0001", "c0002", "c0003"]
     assert [item.claim_id for item in result.deduplication] == [
@@ -606,9 +593,7 @@ async def test_extract_drops_claim_with_unmatched_source_text_after_final_attemp
 async def test_empty_section_selection_is_a_valid_empty_result():
     handler = FakeHandler(["[]"])
     handler.last_successful_model = "actual-model"
-    result = await ClaimExtractor(handler).extract(
-        [section()], model="configured-model"
-    )
+    result = await ClaimExtractor(handler).extract([section()], model="configured-model")
 
     assert result.claims == []
     assert result.deduplication == []

--- a/tests/unit/operations/analysis/paper_claims/test_claim_extractor.py
+++ b/tests/unit/operations/analysis/paper_claims/test_claim_extractor.py
@@ -77,11 +77,14 @@ async def test_extract_repairs_invalid_source_text_and_deduplicates():
             '[{"section_id":"s001"}]',
             json.dumps([{**valid_claim, "original_text": "invented sentence"}]),
             json.dumps([valid_claim]),
-            '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",' '"contradiction":false}]',
+            '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",'
+            '"contradiction":false}]',
         ]
     )
 
-    result = await ClaimExtractor(handler, max_retries=2).extract([section()], source="paper.pdf", model="test")
+    result = await ClaimExtractor(handler, max_retries=2).extract(
+        [section()], source="paper.pdf", model="test"
+    )
 
     assert len(result.claims) == 1
     assert result.claims[0].section_name == "Method"
@@ -104,7 +107,8 @@ async def test_extract_accepts_layout_only_source_text_differences():
         [
             '[{"section_id":"s001"}]',
             json.dumps([candidate]),
-            '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",' '"contradiction":false}]',
+            '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",'
+            '"contradiction":false}]',
         ]
     )
 
@@ -179,7 +183,13 @@ async def test_extract_repairs_minor_original_text_word_drift_with_fuzzy_source_
             '[{"section_id":"s001"}]',
             json.dumps([candidate], ensure_ascii=False),
             json.dumps(
-                [{"claim_id": "c0001", "claim": candidate["claim"], "contradiction": False}],
+                [
+                    {
+                        "claim_id": "c0001",
+                        "claim": candidate["claim"],
+                        "contradiction": False,
+                    }
+                ],
                 ensure_ascii=False,
             ),
         ]
@@ -233,7 +243,13 @@ async def test_extract_accepts_russian_claim_for_short_latin_technical_evidence(
             '[{"section_id":"s001"}]',
             json.dumps([candidate], ensure_ascii=False),
             json.dumps(
-                [{"claim_id": "c0001", "claim": candidate["claim"], "contradiction": False}],
+                [
+                    {
+                        "claim_id": "c0001",
+                        "claim": candidate["claim"],
+                        "contradiction": False,
+                    }
+                ],
                 ensure_ascii=False,
             ),
         ]
@@ -248,7 +264,8 @@ async def test_extract_accepts_russian_claim_for_short_latin_technical_evidence(
 @pytest.mark.asyncio
 async def test_extract_drops_bad_claim_after_retries_and_keeps_valid_claim():
     source_text = (
-        "The model uses BERT-base without fine-tuning. " "The retrieval pipeline uses BM25 for candidate selection."
+        "The model uses BERT-base without fine-tuning. "
+        "The retrieval pipeline uses BM25 for candidate selection."
     )
     paper_section = section().model_copy(update={"text": source_text})
     valid_claim = {
@@ -272,7 +289,13 @@ async def test_extract_drops_bad_claim_after_retries_and_keeps_valid_claim():
             repeated_bad_response,
             repeated_bad_response,
             json.dumps(
-                [{"claim_id": "c0001", "claim": valid_claim["claim"], "contradiction": False}],
+                [
+                    {
+                        "claim_id": "c0001",
+                        "claim": valid_claim["claim"],
+                        "contradiction": False,
+                    }
+                ],
                 ensure_ascii=False,
             ),
         ]
@@ -299,7 +322,8 @@ async def test_extract_repairs_claim_written_in_a_different_script():
             '[{"section_id":"s001"}]',
             json.dumps([chinese_claim], ensure_ascii=False),
             json.dumps([valid_claim]),
-            '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",' '"contradiction":false}]',
+            '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",'
+            '"contradiction":false}]',
         ]
     )
 
@@ -319,7 +343,8 @@ async def test_deduplication_repairs_rewritten_claim_text():
         "verifiability": "high",
     }
     correct_dedup = (
-        '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",' '"contradiction":false}]'
+        '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",'
+        '"contradiction":false}]'
     )
     handler = FakeHandler(
         [
@@ -347,7 +372,8 @@ async def test_deduplication_repairs_empty_response_for_non_empty_input():
         "verifiability": "high",
     }
     correct_dedup = (
-        '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",' '"contradiction":false}]'
+        '[{"claim_id":"c0001","claim":"The model uses BERT-base without fine-tuning.",'
+        '"contradiction":false}]'
     )
     handler = FakeHandler(
         [
@@ -366,7 +392,10 @@ async def test_deduplication_repairs_empty_response_for_non_empty_input():
 
 @pytest.mark.asyncio
 async def test_deduplication_falls_back_after_retries_and_keeps_original_claims():
-    source_text = "The pipeline uses chunked PDF processing. " "The pipeline caches Marker Markdown output."
+    source_text = (
+        "The pipeline uses chunked PDF processing. "
+        "The pipeline caches Marker Markdown output."
+    )
     paper_section = section().model_copy(update={"text": source_text})
     candidates = [
         {
@@ -438,18 +467,57 @@ async def test_batched_deduplication_sends_multiple_requests_and_preserves_order
             json.dumps(candidates),
             json.dumps(
                 [
-                    {"claim_id": "c0001", "claim": candidates[0]["claim"], "contradiction": False},
-                    {"claim_id": "c0002", "claim": candidates[1]["claim"], "contradiction": False},
+                    {
+                        "claim_id": "c0001",
+                        "claim": candidates[0]["claim"],
+                        "contradiction": False,
+                    },
+                    {
+                        "claim_id": "c0002",
+                        "claim": candidates[1]["claim"],
+                        "contradiction": False,
+                    },
                 ]
             ),
-            json.dumps([{"claim_id": "c0003", "claim": candidates[2]["claim"], "contradiction": False}]),
+            json.dumps(
+                [
+                    {
+                        "claim_id": "c0003",
+                        "claim": candidates[2]["claim"],
+                        "contradiction": False,
+                    }
+                ]
+            ),
+            json.dumps(
+                [
+                    {
+                        "claim_id": "c0001",
+                        "claim": candidates[0]["claim"],
+                        "contradiction": False,
+                    },
+                    {
+                        "claim_id": "c0003",
+                        "claim": candidates[2]["claim"],
+                        "contradiction": False,
+                    },
+                ]
+            ),
+            json.dumps(
+                [
+                    {
+                        "claim_id": "c0002",
+                        "claim": candidates[1]["claim"],
+                        "contradiction": False,
+                    }
+                ]
+            ),
         ]
     )
 
     result = await ClaimExtractor(handler, dedup_batch_size=2).extract([paper_section])
 
     assert [claim.claim_id for claim in result.claims] == ["c0001", "c0002", "c0003"]
-    assert len(handler.prompts) == 4
+    assert len(handler.prompts) == 6
     assert '"claim_id": "c0001"' in handler.prompts[2]
     assert '"claim_id": "c0003"' in handler.prompts[3]
 
@@ -491,18 +559,32 @@ async def test_failed_deduplication_batch_does_not_erase_successful_batches():
             json.dumps(candidates),
             json.dumps(
                 [
-                    {"claim_id": "c0001", "claim": candidates[0]["claim"], "contradiction": False},
-                    {"claim_id": "c0002", "claim": candidates[1]["claim"], "contradiction": False},
+                    {
+                        "claim_id": "c0001",
+                        "claim": candidates[0]["claim"],
+                        "contradiction": False,
+                    },
+                    {
+                        "claim_id": "c0002",
+                        "claim": candidates[1]["claim"],
+                        "contradiction": False,
+                    },
                 ]
             ),
             "[]",
         ]
     )
 
-    result = await ClaimExtractor(handler, max_retries=1, dedup_batch_size=2).extract([paper_section])
+    result = await ClaimExtractor(handler, max_retries=1, dedup_batch_size=2).extract(
+        [paper_section]
+    )
 
     assert [claim.claim_id for claim in result.claims] == ["c0001", "c0002", "c0003"]
-    assert [item.claim_id for item in result.deduplication] == ["c0001", "c0002", "c0003"]
+    assert [item.claim_id for item in result.deduplication] == [
+        "c0001",
+        "c0002",
+        "c0003",
+    ]
 
 
 @pytest.mark.asyncio
@@ -524,7 +606,9 @@ async def test_extract_drops_claim_with_unmatched_source_text_after_final_attemp
 async def test_empty_section_selection_is_a_valid_empty_result():
     handler = FakeHandler(["[]"])
     handler.last_successful_model = "actual-model"
-    result = await ClaimExtractor(handler).extract([section()], model="configured-model")
+    result = await ClaimExtractor(handler).extract(
+        [section()], model="configured-model"
+    )
 
     assert result.claims == []
     assert result.deduplication == []

--- a/tests/unit/operations/analysis/paper_claims/test_claim_validation.py
+++ b/tests/unit/operations/analysis/paper_claims/test_claim_validation.py
@@ -1,6 +1,8 @@
 import pytest
 
-from osa_tool.operations.analysis.paper_claims.claim_schemas import ClaimCandidateResponse
+from osa_tool.operations.analysis.paper_claims.claim_schemas import (
+    ClaimCandidateResponse,
+)
 from osa_tool.operations.analysis.paper_claims.claim_validation import (
     partition_valid_claim_candidates,
     validate_claim_candidate,
@@ -38,7 +40,9 @@ def test_validate_claim_candidate_accepts_exact_source_text():
         original_text="The model uses BERT-base without fine-tuning.",
     )
 
-    validate_claim_candidate(candidate, section=make_section("The model uses BERT-base without fine-tuning."))
+    validate_claim_candidate(
+        candidate, section=make_section("The model uses BERT-base without fine-tuning.")
+    )
 
     assert candidate.original_text == "The model uses BERT-base without fine-tuning."
 
@@ -62,15 +66,40 @@ def test_validate_claim_candidate_repairs_minor_source_text_drift():
     assert candidate.original_text == source_text
 
 
+def test_validate_claim_candidate_rejects_numeric_drift_in_fuzzy_evidence():
+    source = "The measured significance threshold was 0.001 for every experiment in the evaluation."
+    candidate = make_candidate(
+        claim="The significance threshold was 0.01.",
+        original_text="The measured significance threshold was 0.01 for every experiment in the evaluation.",
+    )
+
+    with pytest.raises(ValueError, match="original_text is not present"):
+        validate_claim_candidate(candidate, section=make_section(source))
+
+
+def test_validate_claim_candidate_rejects_translation_from_devanagari():
+    source = "यह मॉडल प्रशिक्षण के लिए बड़े डेटासेट का उपयोग करता है।"
+    candidate = make_candidate(
+        claim="The model uses a large training dataset.", original_text=source
+    )
+
+    with pytest.raises(ValueError, match="plausible language script"):
+        validate_claim_candidate(candidate, section=make_section(source))
+
+
 def test_partition_valid_claim_candidates_returns_errors_without_raising():
     section = make_section("The model uses BERT-base without fine-tuning.")
     valid_candidate = make_candidate(
         claim="The model uses BERT-base without fine-tuning.",
         original_text="The model uses BERT-base without fine-tuning.",
     )
-    invalid_candidate = make_candidate(claim="Invented.", original_text="Invented sentence.")
+    invalid_candidate = make_candidate(
+        claim="Invented.", original_text="Invented sentence."
+    )
 
-    valid, invalid = partition_valid_claim_candidates([invalid_candidate, valid_candidate], section=section)
+    valid, invalid = partition_valid_claim_candidates(
+        [invalid_candidate, valid_candidate], section=section
+    )
 
     assert valid == [valid_candidate]
     assert len(invalid) == 1
@@ -84,7 +113,10 @@ def test_validate_claim_candidate_rejects_implausible_claim_script():
     )
 
     with pytest.raises(ValueError, match="plausible language script"):
-        validate_claim_candidate(candidate, section=make_section("The model uses BERT-base without fine-tuning."))
+        validate_claim_candidate(
+            candidate,
+            section=make_section("The model uses BERT-base without fine-tuning."),
+        )
 
 
 def test_validate_claim_candidate_accepts_section_script_for_short_technical_evidence():

--- a/tests/unit/operations/analysis/paper_claims/test_claim_validation.py
+++ b/tests/unit/operations/analysis/paper_claims/test_claim_validation.py
@@ -40,9 +40,7 @@ def test_validate_claim_candidate_accepts_exact_source_text():
         original_text="The model uses BERT-base without fine-tuning.",
     )
 
-    validate_claim_candidate(
-        candidate, section=make_section("The model uses BERT-base without fine-tuning.")
-    )
+    validate_claim_candidate(candidate, section=make_section("The model uses BERT-base without fine-tuning."))
 
     assert candidate.original_text == "The model uses BERT-base without fine-tuning."
 
@@ -79,9 +77,7 @@ def test_validate_claim_candidate_rejects_numeric_drift_in_fuzzy_evidence():
 
 def test_validate_claim_candidate_rejects_translation_from_devanagari():
     source = "यह मॉडल प्रशिक्षण के लिए बड़े डेटासेट का उपयोग करता है।"
-    candidate = make_candidate(
-        claim="The model uses a large training dataset.", original_text=source
-    )
+    candidate = make_candidate(claim="The model uses a large training dataset.", original_text=source)
 
     with pytest.raises(ValueError, match="plausible language script"):
         validate_claim_candidate(candidate, section=make_section(source))
@@ -93,13 +89,9 @@ def test_partition_valid_claim_candidates_returns_errors_without_raising():
         claim="The model uses BERT-base without fine-tuning.",
         original_text="The model uses BERT-base without fine-tuning.",
     )
-    invalid_candidate = make_candidate(
-        claim="Invented.", original_text="Invented sentence."
-    )
+    invalid_candidate = make_candidate(claim="Invented.", original_text="Invented sentence.")
 
-    valid, invalid = partition_valid_claim_candidates(
-        [invalid_candidate, valid_candidate], section=section
-    )
+    valid, invalid = partition_valid_claim_candidates([invalid_candidate, valid_candidate], section=section)
 
     assert valid == [valid_candidate]
     assert len(invalid) == 1

--- a/tests/unit/operations/docs/readme_generation/inputs/test_dependencies.py
+++ b/tests/unit/operations/docs/readme_generation/inputs/test_dependencies.py
@@ -6,12 +6,10 @@ from tests.utils.mocks.repo_trees import get_mock_repo_tree
 
 def test_extract_from_requirements(tmp_path):
     # Arrange
-    require = textwrap.dedent(
-        """
+    require = textwrap.dedent("""
         numpy>=1.21
         pandas==1.5.0
-        """
-    )
+        """)
     (tmp_path / "requirements.txt").write_text(require)
     extractor = DependencyExtractor(get_mock_repo_tree("WITH_REQUIREMENTS_ONLY"), str(tmp_path))
 
@@ -24,16 +22,14 @@ def test_extract_from_requirements(tmp_path):
 
 def test_extract_from_pyproject_pep621(tmp_path):
     # Arrange
-    pyproj = textwrap.dedent(
-        """
+    pyproj = textwrap.dedent("""
         [project]
         dependencies = [
             "flask>=2.0",
             "requests"
         ]
         requires-python = ">=3.9"
-        """
-    )
+        """)
 
     (tmp_path / "pyproject.toml").write_text(pyproj)
 
@@ -48,14 +44,12 @@ def test_extract_from_pyproject_pep621(tmp_path):
 
 def test_extract_from_pyproject_poetry(tmp_path):
     # Arrange
-    pyproj = textwrap.dedent(
-        """
+    pyproj = textwrap.dedent("""
         [tool.poetry.dependencies]
         python = ">=3.8"
         torch = "^1.12"
         transformers = "^4.21"
-        """
-    )
+        """)
     (tmp_path / "pyproject.toml").write_text(pyproj)
 
     extractor = DependencyExtractor(get_mock_repo_tree("WITH_PYPROJECT"), str(tmp_path))
@@ -71,8 +65,7 @@ def test_extract_from_pyproject_poetry(tmp_path):
 
 def test_extract_from_setup_install_requires(tmp_path):
     # Arrange
-    setup_code = textwrap.dedent(
-        """
+    setup_code = textwrap.dedent("""
         from setuptools import setup
 
         setup(
@@ -83,8 +76,7 @@ def test_extract_from_setup_install_requires(tmp_path):
             ],
             python_requires=">=3.7",
         )
-        """
-    )
+        """)
 
     (tmp_path / "setup.py").write_text(setup_code, encoding="utf-8")
 

--- a/tests/unit/tools/paper_claims/test_batch_and_evaluate.py
+++ b/tests/unit/tools/paper_claims/test_batch_and_evaluate.py
@@ -89,9 +89,7 @@ class FakeEmbeddingModel:
 def test_many_to_one_recall_counts_unique_human_matches():
     llm = np.array([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0]])
     human = np.array([[1.0, 0.0], [0.0, 1.0]])
-    metrics = compute_semantic_matching(
-        ["a", "b", "c"], ["x", "y"], model=FakeEmbeddingModel([llm, human])
-    )
+    metrics = compute_semantic_matching(["a", "b", "c"], ["x", "y"], model=FakeEmbeddingModel([llm, human]))
 
     assert metrics["precision"] == 1.0
     assert metrics["recall"] == 0.5

--- a/tests/unit/tools/paper_claims/test_batch_and_evaluate.py
+++ b/tests/unit/tools/paper_claims/test_batch_and_evaluate.py
@@ -1,5 +1,7 @@
 import json
 
+import numpy as np
+
 from osa_tool.tools.paper_claims.batch import build_parser, collect_pdf_inputs
 from osa_tool.tools.paper_claims.evaluate import compute_semantic_matching, load_claims
 
@@ -74,3 +76,40 @@ def test_empty_semantic_matching_does_not_load_optional_dependencies():
 
     assert metrics["num_matched"] == 0
     assert metrics["matching"] == "many_to_one"
+
+
+class FakeEmbeddingModel:
+    def __init__(self, embeddings):
+        self.embeddings = iter(embeddings)
+
+    def encode(self, *_args, **_kwargs):
+        return next(self.embeddings)
+
+
+def test_many_to_one_recall_counts_unique_human_matches():
+    llm = np.array([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0]])
+    human = np.array([[1.0, 0.0], [0.0, 1.0]])
+    metrics = compute_semantic_matching(
+        ["a", "b", "c"], ["x", "y"], model=FakeEmbeddingModel([llm, human])
+    )
+
+    assert metrics["precision"] == 1.0
+    assert metrics["recall"] == 0.5
+    assert metrics["f1"] == 0.6667
+
+
+def test_one_to_one_prioritizes_number_of_threshold_matches():
+    # Directly use unit vectors whose dot products create two valid diagonal
+    # edges while the highest-similarity cross edge blocks them under a plain
+    # maximum-similarity assignment.
+    llm = np.eye(2)
+    human = np.array([[1.0, 0.7], [0.8, 0.8]])
+    metrics = compute_semantic_matching(
+        ["a", "b"],
+        ["x", "y"],
+        threshold=0.75,
+        matching="one_to_one",
+        model=FakeEmbeddingModel([llm, human]),
+    )
+
+    assert metrics["num_matched"] == 2

--- a/tests/unit/utils/test_response_cleaner.py
+++ b/tests/unit/utils/test_response_cleaner.py
@@ -6,9 +6,7 @@ def test_unknown_type_preserves_earliest_object_root():
 
 
 def test_keyed_list_type_applies_after_object_lookup():
-    assert JsonProcessor.parse(
-        '{"files": ["main.py"]}', expected_key="files", expected_type=list
-    ) == ["main.py"]
+    assert JsonProcessor.parse('{"files": ["main.py"]}', expected_key="files", expected_type=list) == ["main.py"]
 
 
 def test_non_json_fence_does_not_hide_later_json():

--- a/tests/unit/utils/test_response_cleaner.py
+++ b/tests/unit/utils/test_response_cleaner.py
@@ -1,0 +1,16 @@
+from osa_tool.utils.response_cleaner import JsonProcessor
+
+
+def test_unknown_type_preserves_earliest_object_root():
+    assert JsonProcessor.parse('answer: {"result": [1, 2]}') == {"result": [1, 2]}
+
+
+def test_keyed_list_type_applies_after_object_lookup():
+    assert JsonProcessor.parse(
+        '{"files": ["main.py"]}', expected_key="files", expected_type=list
+    ) == ["main.py"]
+
+
+def test_non_json_fence_does_not_hide_later_json():
+    response = '```python\nprint("example")\n```\n[{"answer": true}]'
+    assert JsonProcessor.parse(response, expected_type=list) == [{"answer": True}]


### PR DESCRIPTION
### Motivation

- Fix parsing and downstream failures reported in the paper-claims pipeline review (P1/P2) where LLM responses could be mis-extracted, evaluated incorrectly, or cause unsafe repairs/deduplication behavior. 
- Prevent data loss from filename collisions and ensure long sections are not irrecoverably truncated by model transport limits. 
- Improve robustness of fuzzy evidence repair and script-language validation to avoid semantic drift.

### Description

- Improved JSON extraction in `JsonProcessor` to ignore non-JSON fenced blocks, validate fenced payloads, preserve the earliest top-level JSON root when `expected_type` is unspecified, and apply `expected_type` after an `expected_key` lookup (`osa_tool/utils/response_cleaner.py`).
- Adjusted semantic matching in evaluation so `many_to_one` recall counts unique covered human annotations and `one_to_one` matching maximizes the number of above-threshold pairs before optimizing similarity (`osa_tool/tools/paper_claims/evaluate.py`).
- Hardened fuzzy evidence repairs to reject changes that alter numeric/identifier tokens and expanded Unicode script detection (falling back to detected script names) to avoid accepting invalid translations (`osa_tool/operations/analysis/paper_claims/claim_validation.py`).
- Added model-budget-aware, overlapping section chunking for extraction to avoid relying on transport-level middle-out truncation, and added a hierarchical cross-batch deduplication pass that continues until survivors are globally compared (`ClaimExtractor._section_chunks` and hierarchical pass in `osa_tool/operations/analysis/paper_claims/claim_extractor.py`).
- Route request failures through the deduplication fallback so extraction failures do not erase original claims and preserve incoming `contradiction` flags during fallback (`osa_tool/operations/analysis/paper_claims/claim_extractor.py`).
- Prevent filename collisions by deriving a stable, path-based suffix when multiple input PDFs share the same stem (`osa_tool/tools/paper_claims/batch.py`).
- Added and updated unit tests covering response cleaning, fuzzy-evidence behavior, matching metrics, hierarchical deduplication, and related regression cases; applied lint/format fixes.

### Testing

- Ran `ruff check` and `ruff format` on the modified files; formatting and linting issues were fixed and checks passed.
- Executed targeted pytest runs: `pytest -q tests/unit/operations/analysis/paper_claims/test_pipeline.py tests/unit/operations/analysis/paper_claims/test_claim_extractor.py tests/unit/operations/analysis/paper_claims/test_claim_validation.py tests/unit/tools/paper_claims/test_batch_and_evaluate.py tests/unit/utils/test_response_cleaner.py` and all tests passed (`42 passed`, `3 warnings`).
- Additional local test invocations were used while iterating; the final automated test suite and `git diff --check` completed cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6668963c348332917707e1168d7522)