### PR TITLE
fix: JS/TS augmentor robustness + Python grouped imports

### DIFF
--- a/osa_tool/operations/codebase/docstring_generation/adapters/python_adapter.py
+++ b/osa_tool/operations/codebase/docstring_generation/adapters/python_adapter.py
@@ -93,7 +93,13 @@ class PythonAdapter(LanguageAdapter):
             if not os.path.exists(module_path):
                 return import_mapping
 
-            for entity in (e.strip() for e in import_part.split(",")):
+            # a grouped import `from x import (a, b)` (possibly multi-line) keeps the
+            # parentheses/newlines in the raw text; strip them so the names stay clean
+            import_part = import_part.strip().strip("()").replace("\\", " ")
+
+            for entity in (e.strip().strip("()") for e in import_part.split(",")):
+                if not entity or entity == "*":
+                    continue
                 if " as " in entity:
                     imported_name, alias_name = (e.strip() for e in entity.split(" as ", 1))
                 else:

--- a/osa_tool/operations/codebase/docstring_generation/adapters/typescript_adapter.py
+++ b/osa_tool/operations/codebase/docstring_generation/adapters/typescript_adapter.py
@@ -28,10 +28,15 @@ class TypeScriptAdapter(LanguageAdapter):
         if n:
             return sv.text(n)
 
-        # arrow functions / function expressions have no name field;
-        # the name usually sits on the enclosing declarator (const foo = () => ...)
+        # arrow functions / function expressions have no name field; the name usually
+        # sits on the enclosing declarator (const foo = () => ...) or, for a class field
+        # arrow (foo = () => ...), on the surrounding field definition.
         parent = node.parent
-        if parent and parent.type == "variable_declarator":
+        if parent and parent.type in (
+            "variable_declarator",
+            "public_field_definition",
+            "field_definition",
+        ):
             declared = parent.child_by_field_name("name")
             if declared:
                 return sv.text(declared)

--- a/osa_tool/operations/codebase/docstring_generation/insert/ts_js_augmentor.py
+++ b/osa_tool/operations/codebase/docstring_generation/insert/ts_js_augmentor.py
@@ -64,7 +64,17 @@ class TSJSAugmentor(BaseAugmentor):
         used = set()
         actions = []
 
-        for doc, meta in methods:
+        # lines inside an existing comment must never be matched as a declaration
+        # (e.g. a JSDoc body line ` * save(entity) ...` would otherwise look like a
+        # generator method `* save(`), which would corrupt the file on regeneration.
+        comment_idx = self._comment_lines(lines)
+
+        # methods may arrive out of source order (they are generated in dependency
+        # order). Map them to declarations by ascending source position so two methods
+        # sharing a name each get their OWN doc instead of a swapped one.
+        ordered = sorted(methods, key=lambda dm: dm[1].get("start_line", 0))
+
+        for doc, meta in ordered:
             name = meta["method_name"]
             patterns = [
                 # public/private/protected async static method<T>(
@@ -137,7 +147,7 @@ class TSJSAugmentor(BaseAugmentor):
             )
 
             for i, line in enumerate(lines):
-                if i in used:
+                if i in used or i in comment_idx:
                     continue
 
                 stripped = line.strip()
@@ -179,6 +189,68 @@ class TSJSAugmentor(BaseAugmentor):
                 lines.insert(i, self._format(doc, lines[i]))
 
         return lines
+
+    @staticmethod
+    def _scan_comment_state(line, in_block, quote):
+        """Advance the (in_block, quote) lexer state across one line.
+        Honours block comments `/* */`, `//` line comments, and string/template literals
+        (with backslash escapes). `quote` is threaded so a multi-line template literal
+        keeps its state and a `/*` inside it never opens a comment."""
+        i, n = 0, len(line)
+        while i < n:
+            pair = line[i : i + 2]
+            if in_block:
+                if pair == "*/":
+                    in_block = False
+                    i += 2
+                    continue
+                i += 1
+                continue
+            if quote:
+                if line[i] == "\\":
+                    i += 2
+                    continue
+                if line[i] == quote:
+                    quote = None
+                i += 1
+                continue
+            if line[i] in "\"'`":
+                quote = line[i]
+                i += 1
+                continue
+            if pair == "//":
+                break
+            if pair == "/*":
+                in_block = True
+                i += 2
+                continue
+            i += 1
+
+        # only a template literal (backtick) may legally span lines; a dangling ' or "
+        # at end of line is a mis-lexed regex/division, not a real multi-line string, so
+        # drop it instead of leaking the quote state onto the next line.
+        if quote is not None and quote != "`":
+            quote = None
+        return in_block, quote
+
+    @staticmethod
+    def _comment_lines(lines):
+        """Indices of lines whose start sits inside a block comment or a (multi-line)
+        string/template literal, or that are whole-line `//` comments, so declaration
+        patterns are never matched against comment or string text. A line that merely
+        opens a comment/string after real code is NOT marked (its code may be a
+        declaration); only lines that begin inside one are skipped."""
+        marked = set()
+        in_block = False
+        quote = None
+        for i, line in enumerate(lines):
+            if in_block or quote is not None:
+                marked.add(i)
+            elif line.strip().startswith("//"):
+                marked.add(i)
+            in_block, quote = TSJSAugmentor._scan_comment_state(line, in_block, quote)
+
+        return marked
 
     def _has_doc(self, lines, i):
         j = i - 1

--- a/osa_tool/operations/codebase/docstring_generation/insert/ts_js_augmentor.py
+++ b/osa_tool/operations/codebase/docstring_generation/insert/ts_js_augmentor.py
@@ -21,11 +21,14 @@ class TSJSAugmentor(BaseAugmentor):
         return {file: "".join(lines)}
 
     def _inject_classes(self, lines, classes):
+        comment_idx = self._comment_lines(lines)
         for doc, class_name in classes:
 
             class_pattern = re.compile(rf"^\s*(export\s+)?(default\s+)?(abstract\s+)?class\s+{re.escape(class_name)}\b")
 
             for i, line in enumerate(lines):
+                if i in comment_idx:
+                    continue
                 if class_pattern.search(line):
                     if self._has_doc(lines, i):
                         lines = self._replace_doc(lines, i, doc)
@@ -36,7 +39,14 @@ class TSJSAugmentor(BaseAugmentor):
         return lines
 
     def _inject_functions(self, lines, functions):
-        for doc, meta in functions:
+        # same robustness as _inject_methods: skip comment/string lines, map same-named
+        # entries to distinct declarations in source order, and apply bottom-up.
+        used = set()
+        actions = []
+        comment_idx = self._comment_lines(lines)
+        ordered = sorted(functions, key=lambda dm: dm[1].get("start_line", 0))
+
+        for doc, meta in ordered:
             name = meta["method_name"]
             patterns = [
                 re.compile(rf"^\s*export\s+(async\s+)?function\s+{re.escape(name)}\s*\("),
@@ -48,13 +58,18 @@ class TSJSAugmentor(BaseAugmentor):
             ]
 
             for i, line in enumerate(lines):
+                if i in used or i in comment_idx:
+                    continue
                 if any(p.search(line) for p in patterns):
-                    if self._has_doc(lines, i):
-                        lines = self._replace_doc(lines, i, doc)
-                    else:
-                        lines.insert(i, self._format(doc, line))
-
+                    used.add(i)
+                    actions.append((i, doc))
                     break
+
+        for i, doc in sorted(actions, key=lambda a: a[0], reverse=True):
+            if self._has_doc(lines, i):
+                lines = self._replace_doc(lines, i, doc)
+            else:
+                lines.insert(i, self._format(doc, lines[i]))
 
         return lines
 
@@ -174,6 +189,9 @@ class TSJSAugmentor(BaseAugmentor):
                         continue
                     paren = stripped.find("(")
                     before_paren = stripped if paren == -1 else stripped[:paren]
+                    # ignore '=' inside a generic default type param list, e.g.
+                    # `method<T = string>(...)`, which is not an assignment
+                    before_paren = re.sub(r"<[^>]*>", "", before_paren)
                     if "=" in before_paren:
                         continue
 
@@ -313,9 +331,19 @@ class TSJSAugmentor(BaseAugmentor):
         if start != -1:
             end = clean.rfind("*/")
             clean = (clean[start + 3 : end] if end > start + 2 else clean[start + 3 :]).strip()
+        else:
+            # model emitted a closing "*/" delimiter without an opening "/**"; drop a
+            # trailing "*/" so it is not turned into ` * /` junk. An inline "*/" inside
+            # prose (not at the very end) is left for the escape step below.
+            clean = re.sub(r"\s*\*/\s*$", "", clean).strip()
 
-        # drop any residual line that is nothing but a code fence (``` or ```lang)
-        clean = "\n".join(l for l in clean.splitlines() if not re.match(r"^```[a-zA-Z]*$", l.strip()))
+        # drop any residual line that is nothing but a code fence (``` or ```lang) or a
+        # stray JSDoc delimiter (`/**` / `*/`) the model left on its own line
+        clean = "\n".join(
+            l
+            for l in clean.splitlines()
+            if not re.match(r"^```[a-zA-Z]*$", l.strip()) and l.strip() not in ("/**", "*/")
+        )
 
         # remove leading *
         clean_lines = []

--- a/osa_tool/operations/codebase/docstring_generation/insert/ts_js_augmentor.py
+++ b/osa_tool/operations/codebase/docstring_generation/insert/ts_js_augmentor.py
@@ -23,7 +23,7 @@ class TSJSAugmentor(BaseAugmentor):
     def _inject_classes(self, lines, classes):
         for doc, class_name in classes:
 
-            class_pattern = re.compile(rf"^\s*(export\s+)?(abstract\s+)?class\s+{re.escape(class_name)}\b")
+            class_pattern = re.compile(rf"^\s*(export\s+)?(default\s+)?(abstract\s+)?class\s+{re.escape(class_name)}\b")
 
             for i, line in enumerate(lines):
                 if class_pattern.search(line):
@@ -59,6 +59,11 @@ class TSJSAugmentor(BaseAugmentor):
         return lines
 
     def _inject_methods(self, lines, methods):
+        # Decide targets first (pure scan, no mutation) so `used` line indices stay
+        # stable, then apply bottom-up so earlier indices remain valid while we edit.
+        used = set()
+        actions = []
+
         for doc, meta in methods:
             name = meta["method_name"]
             patterns = [
@@ -89,6 +94,19 @@ class TSJSAugmentor(BaseAugmentor):
                     """,
                     re.VERBOSE,
                 ),
+                # generator method: * method<T>(  /  async * method(  /  static * method(
+                re.compile(
+                    rf"""^\s*
+                    (?:public|private|protected|static|readonly|async|\s)*
+                    \*\s*
+                    {re.escape(name)}
+                    \s*
+                    (?:<[^>]*>)?
+                    \s*
+                    \(
+                    """,
+                    re.VERBOSE,
+                ),
                 # method<T>(
                 re.compile(
                     rf"""^\s*
@@ -111,10 +129,21 @@ class TSJSAugmentor(BaseAugmentor):
                     re.VERBOSE,
                 ),
             ]
+            # class field arrow: name = (...) =>  /  name = async (...) =>  /  name = x =>
+            field_arrow = re.compile(
+                rf"^\s*(?:(?:public|private|protected|static|readonly)\s+)*"
+                rf"{re.escape(name)}\s*=\s*(?:async\s+)?"
+                rf"(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*(?::\s*[^=]+?)?\s*=>"
+            )
 
             for i, line in enumerate(lines):
+                if i in used:
+                    continue
+
                 stripped = line.strip()
-                # skip obvious calls/usages
+                is_field_arrow = bool(field_arrow.search(line))
+
+                # skip obvious calls / control-flow / usages
                 if (
                     stripped.startswith("return ")
                     or stripped.startswith("if ")
@@ -124,16 +153,30 @@ class TSJSAugmentor(BaseAugmentor):
                     or stripped.startswith("catch ")
                     or stripped.startswith("new ")
                     or re.search(rf"\.\s*{re.escape(name)}\s*\(", stripped)
-                    or "=" in stripped
                 ):
                     continue
 
-                if any(p.search(line) for p in patterns):
-                    if self._has_doc(lines, i):
-                        lines = self._replace_doc(lines, i, doc)
-                    else:
-                        lines.insert(i, self._format(doc, line))
+                # a statement (ends with ';') or an assignment ('=' before the call
+                # parens) is a call/usage, not a declaration -- skip it. A legitimate
+                # class-field arrow is allowed through (it also ends with ';').
+                if not is_field_arrow:
+                    if stripped.endswith(";"):
+                        continue
+                    paren = stripped.find("(")
+                    before_paren = stripped if paren == -1 else stripped[:paren]
+                    if "=" in before_paren:
+                        continue
+
+                if is_field_arrow or any(p.search(line) for p in patterns):
+                    used.add(i)
+                    actions.append((i, doc))
                     break
+
+        for i, doc in sorted(actions, key=lambda a: a[0], reverse=True):
+            if self._has_doc(lines, i):
+                lines = self._replace_doc(lines, i, doc)
+            else:
+                lines.insert(i, self._format(doc, lines[i]))
 
         return lines
 

--- a/tests/unit/operations/codebase/docstring_generation/test_adapters_robustness.py
+++ b/tests/unit/operations/codebase/docstring_generation/test_adapters_robustness.py
@@ -1,0 +1,64 @@
+from osa_tool.operations.codebase.docstring_generation.adapters.python_adapter import PythonAdapter
+from osa_tool.operations.codebase.docstring_generation.core.osa_parser import OSA_TreeSitter
+
+# --- #5: class-field arrow name resolution (TypeScript adapter) --------------
+
+
+def _method_names(res):
+    names = []
+    for item in res["structure"]:
+        if item.get("type") == "class":
+            names += [m["method_name"] for m in item["methods"]]
+        elif item.get("type") == "function":
+            names.append(item["details"]["method_name"])
+    return names
+
+
+def test_class_field_arrow_gets_name(tmp_path):
+    f = tmp_path / "c.ts"
+    f.write_text(
+        "class C {\n  greet = (name: string): string => 'hi ' + name;\n}\n",
+        encoding="utf-8",
+    )
+    res = OSA_TreeSitter(str(tmp_path)).extract_structure(str(f))
+    names = _method_names(res)
+    assert "greet" in names
+    assert "anonymous" not in names
+
+
+def test_regular_arrow_const_still_named(tmp_path):
+    f = tmp_path / "u.ts"
+    f.write_text("export const mul = (a, b) => a * b;\n", encoding="utf-8")
+    res = OSA_TreeSitter(str(tmp_path)).extract_structure(str(f))
+    assert "mul" in _method_names(res)
+    assert "anonymous" not in _method_names(res)
+
+
+# --- #6: parenthesized / multi-line Python from-imports ----------------------
+
+
+def test_grouped_import_clean_keys(tmp_path):
+    (tmp_path / "mod.py").write_text("a = 1\nb = 2\n", encoding="utf-8")
+    mapping = PythonAdapter._resolve_import_path("from mod import (a, b)", str(tmp_path))
+    assert set(mapping.keys()) == {"a", "b"}
+    assert not any("(" in k or ")" in k for k in mapping)
+
+
+def test_multiline_grouped_import_clean_keys(tmp_path):
+    (tmp_path / "mod.py").write_text("a = 1\nb = 2\nc = 3\n", encoding="utf-8")
+    text = "from mod import (\n    a,\n    b,\n    c,\n)"
+    mapping = PythonAdapter._resolve_import_path(text, str(tmp_path))
+    assert set(mapping.keys()) == {"a", "b", "c"}
+
+
+def test_grouped_import_with_alias(tmp_path):
+    (tmp_path / "mod.py").write_text("a = 1\nb = 2\n", encoding="utf-8")
+    mapping = PythonAdapter._resolve_import_path("from mod import (a as x, b)", str(tmp_path))
+    assert set(mapping.keys()) == {"x", "b"}
+    assert mapping["x"]["class"] == "a"
+
+
+def test_plain_import_still_works(tmp_path):
+    (tmp_path / "mod.py").write_text("a = 1\n", encoding="utf-8")
+    mapping = PythonAdapter._resolve_import_path("from mod import a", str(tmp_path))
+    assert set(mapping.keys()) == {"a"}

--- a/tests/unit/operations/codebase/docstring_generation/test_ts_js_augmentor.py
+++ b/tests/unit/operations/codebase/docstring_generation/test_ts_js_augmentor.py
@@ -409,3 +409,85 @@ def test_regex_with_apostrophe_does_not_suppress_methods():
     lines = out.splitlines()
     decl = next(i for i, l in enumerate(lines) if "save(entity) {" in l)
     assert lines[decl - 1].strip() == "*/"
+
+
+def test_method_with_generic_default_type_param_documented():
+    """A method with a generic default type param `<T = X>` must be documented (the '='
+    inside the generic list is not an assignment)."""
+    aug = TSJSAugmentor()
+    src = "class C {\n\tmap<T = string>(x) {\n\t\treturn x;\n\t}\n}\n"
+    out = aug.augment(
+        "f.ts",
+        src,
+        {"methods": [("Maps x.", {"method_name": "map", "start_line": 2})]},
+    )["f.ts"]
+
+    assert "Maps x." in out
+    lines = out.splitlines()
+    decl = next(i for i, l in enumerate(lines) if "map<T = string>(x)" in l)
+    assert lines[decl - 1].strip() == "*/"
+
+
+def _augment_functions(docs_metas, source):
+    aug = TSJSAugmentor()
+    return aug.augment("f.ts", source, {"functions": docs_metas})["f.ts"]
+
+
+def test_functions_same_name_mapped_by_source_order():
+    """Two same-named top-level functions each get their OWN doc in source order
+    (functions injector now has the same anti-swap logic as methods)."""
+    src = "function handle(a) {\n\treturn a;\n}\n" "function handle(b) {\n\treturn b;\n}\n"
+    out = _augment_functions(
+        [
+            ("Doc two.", {"method_name": "handle", "start_line": 4}),
+            ("Doc one.", {"method_name": "handle", "start_line": 1}),
+        ],
+        src,
+    )
+    lines = out.splitlines()
+    idxs = [i for i, l in enumerate(lines) if "function handle(" in l]
+    assert len(idxs) == 2
+    for idx in idxs:
+        assert lines[idx - 1].strip() == "*/"
+    assert out.index("Doc one.") < out.index("Doc two.")
+
+
+def test_function_example_in_block_comment_not_matched():
+    """A `function build(` line inside a block comment must not be matched as the real fn."""
+    src = "/*\n" "function build(x) is deprecated.\n" "*/\n" "function build(x) {\n\treturn x;\n}\n"
+    out = _augment_functions([("Builds x.", {"method_name": "build", "start_line": 4})], src)
+
+    assert "Builds x." in out
+    assert "function build(x) is deprecated" in out
+    lines = out.splitlines()
+    decl = next(i for i, l in enumerate(lines) if "function build(x) {" in l)
+    assert lines[decl - 1].strip() == "*/"
+
+
+def test_format_strips_bare_trailing_close_delimiter():
+    """Model returns a doc ending in a bare '*/' with no opening '/**' -> the delimiter
+    must be dropped, not turned into ' * /' junk (regression from a live class-doc)."""
+    aug = TSJSAugmentor()
+    # no opening /**, just body + a stray closing delimiter on its own line
+    doc = "Represents a generic shape.\n*/"
+    source = "class Shape {\n\tarea() {}\n}\n"
+    out = aug.augment("f.ts", source, {"classes": [(doc, "Shape")]})["f.ts"]
+
+    assert "Represents a generic shape." in out
+    assert "* /" not in out
+    assert out.count("/**") == 1
+    assert out.count("*/") == 1
+
+
+def test_format_drops_standalone_delimiter_line():
+    """A stray '*/' left on its own line inside the model output (e.g. an echoed wrapper
+    plus an extra close on the update pass) must be dropped, not become ' * /' junk."""
+    aug = TSJSAugmentor()
+    doc = "/**\n * Represents a shape.\n */\n */"
+    source = "class Shape {\n\tarea() {}\n}\n"
+    out = aug.augment("f.ts", source, {"classes": [(doc, "Shape")]})["f.ts"]
+
+    assert "Represents a shape." in out
+    assert "* /" not in out
+    assert out.count("/**") == 1
+    assert out.count("*/") == 1

--- a/tests/unit/operations/codebase/docstring_generation/test_ts_js_augmentor.py
+++ b/tests/unit/operations/codebase/docstring_generation/test_ts_js_augmentor.py
@@ -112,3 +112,124 @@ def test_format_plain_text_unchanged_behaviour():
     assert "```" not in out
     assert out.count("/**") == 1
     assert out.count("*/") == 1
+
+
+# --- robustness fixes: class/method injection edge cases ---------------------
+
+
+def _line_above(out, decl_substring):
+    """Return the stripped line directly above the first line containing decl_substring."""
+    lines = out.splitlines()
+    for i, l in enumerate(lines):
+        if decl_substring in l:
+            return lines[i - 1].strip() if i > 0 else ""
+    return None
+
+
+def test_inject_export_default_class():
+    """`export default class X` must receive a class-level JSDoc (regex #1)."""
+    aug = TSJSAugmentor()
+    src = "export default class Queue {\n\tclear() {}\n}\n"
+    out = aug.augment("f.ts", src, {"classes": [("A FIFO queue.", "Queue")]})["f.ts"]
+
+    assert "A FIFO queue." in out
+    assert _line_above(out, "export default class Queue") == "*/"
+
+
+def test_inject_generator_method():
+    """Generator methods (`* gen()`) must be matched and documented (#4)."""
+    aug = TSJSAugmentor()
+    src = "class Q {\n\t* drain() {\n\t\tyield 1;\n\t}\n}\n"
+    out = aug.augment("f.ts", src, {"methods": [("Drains the queue.", {"method_name": "drain"})]})["f.ts"]
+
+    assert "Drains the queue." in out
+    assert _line_above(out, "* drain()") == "*/"
+
+
+def test_inject_two_same_named_methods_both_documented():
+    """Two methods with the same name must each get their own doc, in order (#2)."""
+    aug = TSJSAugmentor()
+    src = (
+        "class Node {\n\tconstructor(value) {\n\t\tthis.value = value;\n\t}\n}\n"
+        "class Queue {\n\tconstructor() {\n\t\tthis.clear();\n\t}\n}\n"
+    )
+    docs = {
+        "methods": [
+            ("Node constructor.", {"method_name": "constructor"}),
+            ("Queue constructor.", {"method_name": "constructor"}),
+        ]
+    }
+    out = aug.augment("f.ts", src, docs)["f.ts"]
+
+    assert out.count("constructor(") == 2
+    assert "Node constructor." in out
+    assert "Queue constructor." in out
+    # both declarations carry a doc block directly above them
+    lines = out.splitlines()
+    ctor_idxs = [i for i, l in enumerate(lines) if "constructor(" in l]
+    assert len(ctor_idxs) == 2
+    for idx in ctor_idxs:
+        assert lines[idx - 1].strip() == "*/"
+    # order preserved: first constructor -> first doc
+    assert out.index("Node constructor.") < out.index("Queue constructor.")
+
+
+def test_inject_method_with_default_param_value():
+    """A method whose signature line contains `=` (default value) must be documented (#3)."""
+    aug = TSJSAugmentor()
+    src = "class C {\n\tscale(x, factor = 2) {\n\t\treturn x * factor;\n\t}\n}\n"
+    out = aug.augment("f.ts", src, {"methods": [("Scales a value.", {"method_name": "scale"})]})["f.ts"]
+
+    assert "Scales a value." in out
+    assert _line_above(out, "scale(x, factor = 2)") == "*/"
+
+
+def test_assignment_is_not_mistaken_for_method():
+    """A local assignment must NOT be documented as a method (guard still holds)."""
+    aug = TSJSAugmentor()
+    src = "class C {\n\trun() {\n\t\tconst compute = helper(1);\n\t\treturn compute;\n\t}\n}\n"
+    out = aug.augment("f.ts", src, {"methods": [("Computes.", {"method_name": "compute"})]})["f.ts"]
+
+    assert "Computes." not in out
+
+
+def test_inject_class_field_arrow_method():
+    """A class-field arrow (`name = (...) => ...`) must be documented (#5, injection)."""
+    aug = TSJSAugmentor()
+    src = "class C {\n\tgreet = (name) => 'hi ' + name;\n}\n"
+    out = aug.augment("f.ts", src, {"methods": [("Greets by name.", {"method_name": "greet"})]})["f.ts"]
+
+    assert "Greets by name." in out
+    assert _line_above(out, "greet = (name) =>") == "*/"
+
+
+def test_bare_call_with_operator_not_documented():
+    """A bare call statement whose args contain `===`/`>=`/etc must NOT be mistaken
+    for a method declaration; the real same-named method gets the doc instead (#3 guard)."""
+    aug = TSJSAugmentor()
+    src = (
+        "class S {\n"
+        "\tboot() {\n"
+        "\t\tassert(ready === true);\n"
+        "\t}\n"
+        "\tassert(cond) {\n"
+        "\t\treturn cond;\n"
+        "\t}\n"
+        "}\n"
+    )
+    docs = {
+        "methods": [
+            ("Boots the service.", {"method_name": "boot"}),
+            ("Asserts a condition.", {"method_name": "assert"}),
+        ]
+    }
+    out = aug.augment("f.ts", src, docs)["f.ts"]
+    lines = out.splitlines()
+
+    # the call statement must NOT receive a doc
+    call_idx = next(i for i, l in enumerate(lines) if "assert(ready === true)" in l)
+    assert lines[call_idx - 1].strip() != "*/"
+    # the real declaration does
+    decl_idx = next(i for i, l in enumerate(lines) if "assert(cond)" in l)
+    assert lines[decl_idx - 1].strip() == "*/"
+    assert "Asserts a condition." in out

--- a/tests/unit/operations/codebase/docstring_generation/test_ts_js_augmentor.py
+++ b/tests/unit/operations/codebase/docstring_generation/test_ts_js_augmentor.py
@@ -233,3 +233,179 @@ def test_bare_call_with_operator_not_documented():
     decl_idx = next(i for i, l in enumerate(lines) if "assert(cond)" in l)
     assert lines[decl_idx - 1].strip() == "*/"
     assert "Asserts a condition." in out
+
+
+def test_same_named_methods_mapped_by_source_order():
+    """When entries arrive out of source order (dependency order), each doc must land
+    on the method at its own start_line, not get swapped (regression for the swap bug)."""
+    aug = TSJSAugmentor()
+    src = (
+        "class A {\n\tadd(item, priority = 0) {\n\t\treturn item;\n\t}\n}\n"
+        "class B {\n\tadd(key, value) {\n\t\treturn key;\n\t}\n}\n"
+    )
+    # entries deliberately reversed (B.add first) to mimic dependency-order output
+    docs = {
+        "methods": [
+            ("Doc for B add.", {"method_name": "add", "start_line": 7}),
+            ("Doc for A add.", {"method_name": "add", "start_line": 2}),
+        ]
+    }
+    out = aug.augment("f.ts", src, docs)["f.ts"]
+    lines = out.splitlines()
+
+    a_idx = next(i for i, l in enumerate(lines) if "add(item, priority = 0)" in l)
+    b_idx = next(i for i, l in enumerate(lines) if "add(key, value)" in l)
+    a_block = "\n".join(lines[max(0, a_idx - 4) : a_idx])
+    b_block = "\n".join(lines[max(0, b_idx - 4) : b_idx])
+
+    assert "Doc for A add." in a_block
+    assert "Doc for B add." in b_block
+
+
+def test_comment_body_not_matched_as_declaration():
+    """A JSDoc body line like ` * save(entity) ...` must not be matched as the method
+    declaration (the generator `*` pattern must not hit comment lines and corrupt the
+    file). Regenerating updates the real method's doc instead."""
+    aug = TSJSAugmentor()
+    src = (
+        "class Repo {\n"
+        "\t/**\n"
+        "\t * save(entity) persists the record.\n"
+        "\t */\n"
+        "\tsave(entity) {\n"
+        "\t\treturn entity;\n"
+        "\t}\n"
+        "}\n"
+    )
+    out = aug.augment(
+        "f.ts",
+        src,
+        {"methods": [("Persists the entity.", {"method_name": "save", "start_line": 5})]},
+    )["f.ts"]
+
+    assert "Persists the entity." in out
+    # exactly one JSDoc block (the method's, replaced) -> no nested/corrupted /**
+    assert out.count("/**") == 1
+    lines = out.splitlines()
+    decl = next(i for i, l in enumerate(lines) if "save(entity) {" in l)
+    assert lines[decl - 1].strip() == "*/"
+
+
+def test_block_comment_line_not_matched_as_declaration():
+    """A plain block-comment line starting with a method name must not be matched."""
+    aug = TSJSAugmentor()
+    src = (
+        "class Repo {\n"
+        "\t/*\n"
+        "\tload(id) is deprecated, use fetch instead.\n"
+        "\t*/\n"
+        "\tload(id) {\n"
+        "\t\treturn id;\n"
+        "\t}\n"
+        "}\n"
+    )
+    out = aug.augment(
+        "f.ts",
+        src,
+        {"methods": [("Loads by id.", {"method_name": "load", "start_line": 5})]},
+    )["f.ts"]
+
+    assert "Loads by id." in out
+    # the doc must land above the real declaration, not inside the block comment
+    lines = out.splitlines()
+    decl = next(i for i, l in enumerate(lines) if "load(id) {" in l)
+    assert lines[decl - 1].strip() == "*/"
+    # the deprecated block-comment text is untouched (still present, not wrapped in /**)
+    assert "load(id) is deprecated" in out
+
+
+def test_method_with_inline_block_comment_still_documented():
+    """A method whose declaration line has an inline `/* */` comment must still be
+    documented (single-line block comments are not treated as comment lines)."""
+    aug = TSJSAugmentor()
+    src = "class C {\n\tparse(url) /* TODO */ {\n\t\treturn url;\n\t}\n}\n"
+    out = aug.augment(
+        "f.ts",
+        src,
+        {"methods": [("Parses a URL.", {"method_name": "parse", "start_line": 2})]},
+    )["f.ts"]
+
+    assert "Parses a URL." in out
+    lines = out.splitlines()
+    decl = next(i for i, l in enumerate(lines) if "parse(url)" in l)
+    assert lines[decl - 1].strip() == "*/"
+
+
+def test_string_literal_slash_star_does_not_suppress_methods():
+    """A `/*` inside a string literal must NOT open a phantom comment block that
+    suppresses documentation of later methods (literal-aware comment scan)."""
+    aug = TSJSAugmentor()
+    src = "class Repo {\n" '\tglob = "src/*";\n' "\tsave(entity) {\n\t\treturn entity;\n\t}\n" "}\n"
+    out = aug.augment(
+        "f.ts",
+        src,
+        {"methods": [("Saves the entity.", {"method_name": "save", "start_line": 3})]},
+    )["f.ts"]
+
+    assert "Saves the entity." in out
+    lines = out.splitlines()
+    decl = next(i for i, l in enumerate(lines) if "save(entity) {" in l)
+    assert lines[decl - 1].strip() == "*/"
+
+
+def test_declaration_opening_trailing_block_comment_still_documented():
+    """A declaration line that also opens a multi-line comment after the code must still
+    be documented (the code part is a real declaration)."""
+    aug = TSJSAugmentor()
+    src = "class I {\n" "\tsave(entity) { /* note:\n" "\t   multi-line */\n" "\t\treturn entity;\n" "\t}\n" "}\n"
+    out = aug.augment(
+        "f.ts",
+        src,
+        {"methods": [("Saves it.", {"method_name": "save", "start_line": 2})]},
+    )["f.ts"]
+
+    assert "Saves it." in out
+    lines = out.splitlines()
+    decl = next(i for i, l in enumerate(lines) if "save(entity)" in l and "*" != l.strip()[:1])
+    assert lines[decl - 1].strip() == "*/"
+
+
+def test_multiline_template_literal_does_not_suppress_methods():
+    """A multi-line template literal containing '/*' must not open a phantom comment
+    block (quote state is threaded across lines), so later methods stay documented."""
+    aug = TSJSAugmentor()
+    src = (
+        "class Q {\n"
+        "\tsql = `\n"
+        "\t\tSELECT /* unclosed marker\n"
+        "\t`;\n"
+        "\tsave(entity) {\n\t\treturn entity;\n\t}\n"
+        "}\n"
+    )
+    out = aug.augment(
+        "f.ts",
+        src,
+        {"methods": [("Saves it.", {"method_name": "save", "start_line": 5})]},
+    )["f.ts"]
+
+    assert "Saves it." in out
+    lines = out.splitlines()
+    decl = next(i for i, l in enumerate(lines) if "save(entity) {" in l)
+    assert lines[decl - 1].strip() == "*/"
+
+
+def test_regex_with_apostrophe_does_not_suppress_methods():
+    """A regex literal containing a lone quote char (e.g. /O'Brien/) must not leave a
+    dangling string state that suppresses documentation of later methods."""
+    aug = TSJSAugmentor()
+    src = "class M {\n" "\tre = /O'Brien/;\n" "\tsave(entity) {\n\t\treturn entity;\n\t}\n" "}\n"
+    out = aug.augment(
+        "f.ts",
+        src,
+        {"methods": [("Saves it.", {"method_name": "save", "start_line": 3})]},
+    )["f.ts"]
+
+    assert "Saves it." in out
+    lines = out.splitlines()
+    decl = next(i for i, l in enumerate(lines) if "save(entity) {" in l)
+    assert lines[decl - 1].strip() == "*/"


### PR DESCRIPTION
Всплыло после мержа #462

## Что поправил

- **`export default class`** теперь получает class-level JSDoc (раньше regex ловил только `class` / `export class` / `abstract class`).
- **Два одноимённых метода** (например, по конструктору в двух классах одного файла) документируются оба. Раньше стоял `break` после первого совпадения, и второй метод оставался без дока. Переписал на two-phase: сначала собираю цели, потом вставляю снизу вверх, чтобы индексы строк не разъезжались.
- **Метод с `=` в сигнатуре** (дефолтный параметр, `foo(x = 5) {`) больше не пропускается. Старая эвристика рубила любую строку с `=`, теперь скипаем только настоящие присваивания и вызовы-стейтменты.
- **Генераторы** `* gen()` и `* [Symbol.iterator]()` теперь матчатся и документируются.
- **Стрелки-поля класса** (`foo = (x) => ...`) получают имя из объявления поля, а не уходят как `anonymous`. Правка в TypeScript-адаптере (`get_name`) плюс отдельный паттерн вставки.
- **Скобочные и многострочные Python-импорты** (`from x import (a, b)`) больше не дают мусорные ключи вроде `(a` / `b)`. Снимаем скобки и переносы перед разбором.

## Тесты

- `test_ts_js_augmentor.py` дополнил кейсами на все случаи выше плюс негативные проверки: голый вызов с оператором в аргументах (`assert(ready === true);`) и локальное присваивание не должны приниматься за объявление метода.
- Новый `test_adapters_robustness.py` на резолв имени стрелки-поля и на разбор grouped/multiline/alias импортов.
