### PR TITLE
fix: load_dotenv(override=True) so .env overrides stale OS env vars

### DIFF
--- a/osa_tool/core/git/git_agent.py
+++ b/osa_tool/core/git/git_agent.py
@@ -55,7 +55,10 @@ class GitAgent(abc.ABC):
             branch_name: The name of the branch to be created. Defaults to "osa_tool".
             author: The name of the author of the pull request.
         """
-        load_dotenv()
+        # override=True so values from .env take precedence over a stale variable
+        # already present in the OS environment (otherwise a leftover token/key shadows
+        # the freshly configured .env value)
+        load_dotenv(override=True)
         self.author = author
         self.repo_url = repo_url
         self.clone_dir = str(resolve_repo_path(repo_url))

--- a/osa_tool/core/git/metadata.py
+++ b/osa_tool/core/git/metadata.py
@@ -13,7 +13,8 @@ from osa_tool.core.git.request_utils import request_with_retry
 from osa_tool.utils.logger import logger
 from osa_tool.utils.utils import get_base_repo_url
 
-load_dotenv()
+# override=True so .env takes precedence over a stale OS-environment variable
+load_dotenv(override=True)
 
 
 def _normalize_issues_url(url: str | None) -> str | None:

--- a/osa_tool/core/llm/llm.py
+++ b/osa_tool/core/llm/llm.py
@@ -556,7 +556,10 @@ class ProtollmHandler(ModelHandler):
         Returns:
             None
         """
-        dotenv.load_dotenv()
+        # override=True so an updated API key in .env is honoured even when a stale
+        # key is still present in the OS environment (its absence caused confusing
+        # 401 "User not found" errors)
+        dotenv.load_dotenv(override=True)
 
         self.client = create_llm_connector(
             model_url=self._build_model_url(model_name),

--- a/tests/unit/core/git/test_git_agent.py
+++ b/tests/unit/core/git/test_git_agent.py
@@ -33,6 +33,9 @@ def git_agent_base_setup(temp_clone_dir, mock_repository_metadata, repo_info, mo
     platform, owner, repo_name, repo_url = repo_info
 
     monkeypatch.setenv("GIT_TOKEN", "fake-token-base-setup")
+    # isolate from a real .env on disk: GitAgent calls load_dotenv(override=True), which
+    # would otherwise clobber the fake token above with the developer's real token
+    monkeypatch.setattr("osa_tool.core.git.git_agent.load_dotenv", lambda *a, **k: None)
 
     with patch.object(GitHubMetadataLoader, "load_data", return_value=mock_repository_metadata):
         agent = GitHubAgent(repo_url)
@@ -529,6 +532,9 @@ def test_gitverse_agent_star_repository_already_starred(
 def sourcecraft_agent_instance(temp_clone_dir, mock_repository_metadata, repo_info, monkeypatch):
     platform, owner, repo_name, repo_url = repo_info
     monkeypatch.setenv("SOURCECRAFT_TOKEN", "fixture-token-sourcecraft")
+    # isolate from a real .env on disk (see git_agent_base_setup): load_dotenv(override=True)
+    # would otherwise replace the fixture token with the developer's real one
+    monkeypatch.setattr("osa_tool.core.git.git_agent.load_dotenv", lambda *a, **k: None)
     with patch("osa_tool.core.git.git_agent.SourceCraftMetadataLoader", create=True) as mock_loader:
         mock_loader.load_data.return_value = mock_repository_metadata
         agent = SourceCraftAgent(repo_url)

--- a/tests/unit/core/llm/test_llm.py
+++ b/tests/unit/core/llm/test_llm.py
@@ -161,6 +161,21 @@ def test_model_handler_factory_builds_correct_type(mock_config_manager):
     assert isinstance(handler, ProtollmHandler)
 
 
+def test_configure_api_loads_dotenv_with_override(mock_config_manager, patch_llm_connector, mocker):
+    # Arrange: spy on load_dotenv so we can assert how it is invoked
+    spy = mocker.patch("osa_tool.core.llm.llm.dotenv.load_dotenv")
+    model_settings = mock_config_manager.get_model_settings("general")
+
+    # Act
+    ProtollmHandler(model_settings)
+
+    # Assert: .env must take precedence over a stale key already in the OS environment
+    # (a stale OPENAI key otherwise shadows the updated .env value -> 401 "User not found")
+    assert spy.called
+    for call in spy.call_args_list:
+        assert call.kwargs.get("override") is True
+
+
 def test_protollm_handler_init(mock_config_manager):
     # Arrange
     model_settings = mock_config_manager.get_model_settings("general")


### PR DESCRIPTION
`load_dotenv()` по умолчанию идёт с `override=False`, то есть переменная, уже сидящая в окружении ОС, побеждает значение из `.env`. Из-за этого устаревший ключ в среде (например, старый `OPENAI_API_KEY`) затеняет свежий ключ из `.env`, и запросы к модели падают с невнятным `401 "User not found"` при том, что в `.env` всё правильно.

Отлаживается это неприятно: код и `.env` выглядят корректно, а ошибка приходит с сервера. 

Добавил `override=True` во все места, где грузится `.env`.

Теперь `.env` - источник истины: обновил ключ в `.env`, и он реально применяется, даже если в окружении болтается старый.

`.env` теперь имеет приоритет над OS-env. В CI без `.env` ничего не меняется; локально `.env` становится авторитетным.
