### PR TITLE
fix: guard None class docstring in update_class_documentation

### DIFF
--- a/osa_tool/operations/codebase/docstring_generation/docgen.py
+++ b/osa_tool/operations/codebase/docstring_generation/docgen.py
@@ -244,6 +244,11 @@ class DocGen(object):
         Returns:
             The generated class docstring.
         """
+        # a class without an existing docstring has nothing to "update"; the caller drops
+        # empty results, so return "" instead of crashing on None in the split/strip below
+        if not class_details[-1]:
+            return ""
+
         # Construct a structured prompt
         try:
             desc, other = class_details[-1].split("\n\n", maxsplit=1)
@@ -1206,12 +1211,14 @@ class DocGen(object):
                 else:
                     docstring = component["details"]["docstring"] if component["details"]["docstring"] else ""
 
-                prompt_structure.append(f"""
+                prompt_structure.append(
+                    f"""
                     {_type.capitalize()} name: {component["name"] if _type == "class" else component["details"]["method_name"]}
                     Component description: {docstring}
                     Component place in hierarchy: {file}
                     Component importance score: {score}
-                    """)
+                    """
+                )
 
         logger.info(f"Generating the main idea of the project...")
 

--- a/tests/unit/operations/codebase/docstring_generation/test_docgen.py
+++ b/tests/unit/operations/codebase/docstring_generation/test_docgen.py
@@ -241,6 +241,23 @@ async def test_update_class_documentation(mock_config_manager):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("existing_docstring", [None, ""])
+async def test_update_class_documentation_empty_docstring_returns_empty(mock_config_manager, existing_docstring):
+    # a class with no existing docstring reaches update_class_documentation in the
+    # main-idea pass; it must return "" (dropped by the caller) instead of crashing
+    docgen = DocGen(mock_config_manager)
+    docgen.model_handler.async_request = AsyncMock(return_value="should not be called")
+    docgen.main_idea = "Main idea here"
+
+    class_details = ["MyClass", "Other info", existing_docstring]  # last element = existing class docstring
+
+    result = await docgen.update_class_documentation(class_details, asyncio.Semaphore(1))
+
+    assert result == ""
+    docgen.model_handler.async_request.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_generate_method_documentation(mock_config_manager):
     # Arrange
     docgen = DocGen(mock_config_manager)


### PR DESCRIPTION
В проходе обновления по main idea (`incremental=False`) ВСЕ классы уходят в `update_class_documentation` - в том числе классы без докстринга. А метод сразу делает `class_details[-1].split("\n\n", ...)`, и в `except`-фолбэке - `class_details[-1].strip()`. Когда у класса нет докстринга, `class_details[-1]` это `None`, и обе строки падают с `AttributeError: 'NoneType' has no attribute
'split'/'strip'`.

Падает не тихо: исключение рушит весь batch обновления классов через `asyncio.gather`, и `DocstringsGenerator.run()` возвращает `{"result": None}` - хотя докстринги функций/методов к этому моменту уже записаны.

Воспроизводится на реальном репо `sindresorhus/yocto-queue`: классы `Node`/`Queue` без докстрингов -> краш в update-проходе -> `run()` -> `None`.

Поправил.
